### PR TITLE
Interface, rewriting, and write QUIL

### DIFF
--- a/include/tweedledum/algorithms/generic/rewrite.hpp
+++ b/include/tweedledum/algorithms/generic/rewrite.hpp
@@ -1,0 +1,27 @@
+/*------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+| Author(s): Mathias Soeken
+*-----------------------------------------------------------------------------*/
+#pragma once
+
+namespace tweedledum {
+
+template<class NetworkDest, class NetworkSrc, class RewriteFn>
+void rewrite_network(NetworkDest& dest, NetworkSrc const& src, RewriteFn&& fn, uint32_t ancillae = 0)
+{
+	for (auto i = 0u; i < src.num_qubits() + ancillae; ++i) {
+		dest.allocate_qubit();
+	}
+
+	src.foreach_node([&](auto const& n) {
+		if (!fn(dest, n.gate)) {
+			if constexpr (std::is_same_v<typename NetworkSrc::gate_type,
+			                             typename NetworkDest::gate_type>) {
+				dest.add_gate(n.gate);
+			}
+		}
+	});
+}
+
+} // namespace tweedledum

--- a/include/tweedledum/algorithms/mapping/relative_phase.hpp
+++ b/include/tweedledum/algorithms/mapping/relative_phase.hpp
@@ -1,0 +1,171 @@
+/*------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+| Author(s): Mathias Soeken
+*-----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../../networks/gates/gate_kinds.hpp"
+#include "../generic/rewrite.hpp"
+
+namespace tweedledum {
+
+template<class NetworkDest, class NetworkSrc>
+void relative_phase_mapping(NetworkDest& dest, NetworkSrc const& src)
+{
+	rewrite_network(dest, src, [](auto& dest, auto const& g) {
+		if (g.is(gate_kinds_t::mcx)) {
+			switch (g.num_controls()) {
+			default:
+				return false;
+			case 0:
+				g.foreach_target([&](auto t) {
+					dest.add_gate(gate_kinds_t::pauli_x, t);
+				});
+				break;
+			case 1:
+				g.foreach_control([&](auto c) {
+					g.foreach_target([&](auto t) {
+						dest.add_controlled_gate(
+						    gate_kinds_t::cx, c, t);
+					});
+				});
+				break;
+			case 2: {
+				uint32_t controls[2];
+				auto* p = controls;
+				g.foreach_control([&](auto c) { *p++ = c; });
+
+				std::vector<uint32_t> targets(g.num_targets());
+				auto it = targets.begin();
+				g.foreach_target([&](auto t) { *it++ = t; });
+
+				for (auto i = 1u; i < targets.size(); ++i) {
+					dest.add_controlled_gate(gate_kinds_t::cx,
+					                         targets[0],
+					                         targets[i]);
+				}
+
+				const auto a = controls[0];
+				const auto b = controls[1];
+				const auto c = targets[0];
+
+				dest.add_gate(gate_kinds_t::hadamard, c);
+				dest.add_controlled_gate(gate_kinds_t::cx, c, b);
+				dest.add_gate(gate_kinds_t::t_dagger, b);
+				dest.add_controlled_gate(gate_kinds_t::cx, a, b);
+				dest.add_gate(gate_kinds_t::t, b);
+				dest.add_controlled_gate(gate_kinds_t::cx, c, a);
+				dest.add_gate(gate_kinds_t::t_dagger, b);
+				dest.add_controlled_gate(gate_kinds_t::cx, a, b);
+				dest.add_gate(gate_kinds_t::t, b);
+				dest.add_controlled_gate(gate_kinds_t::cx, a, c);
+				dest.add_gate(gate_kinds_t::t_dagger, c);
+				dest.add_controlled_gate(gate_kinds_t::cx, a, c);
+				dest.add_gate(gate_kinds_t::t, a);
+				dest.add_gate(gate_kinds_t::t, c);
+				dest.add_gate(gate_kinds_t::hadamard, c);
+
+				for (auto i = 1u; i < targets.size(); ++i) {
+					dest.add_controlled_gate(gate_kinds_t::cx,
+					                         targets[0],
+					                         targets[i]);
+				}
+			} break;
+			case 3: {
+				uint32_t controls[3];
+				auto* p = controls;
+				g.foreach_control([&](auto c) { *p++ = c; });
+
+				std::vector<uint32_t> targets(g.num_targets());
+				auto it = targets.begin();
+				g.foreach_target([&](auto t) { *it++ = t; });
+
+				const auto a = controls[0];
+				const auto b = controls[1];
+				const auto c = controls[2];
+				const auto d = targets[0];
+
+				int32_t hl = -1;
+				for (auto i = 0u; i < dest.num_qubits(); ++i) {
+					if (i != a && i != b && i != c
+					    && (std::find(targets.begin(),
+					                  targets.end(), i)
+					        == targets.end())) {
+						hl = i;
+						break;
+					}
+				}
+
+				if (hl == -1) {
+					std::cout
+					    << "[e] no sufficient helper line "
+					       "found for mapping, break\n";
+					return false;
+				}
+
+				for (auto i = 1u; i < targets.size(); ++i) {
+					dest.add_controlled_gate(
+					    gate_kinds_t::cx, d, targets[i]);
+				}
+
+				// R1-TOF(a, b, hl)
+				dest.add_gate(gate_kinds_t::hadamard, hl);
+				dest.add_gate(gate_kinds_t::t, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, b, hl);
+				dest.add_gate(gate_kinds_t::t_dagger, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, a, hl);
+				dest.add_gate(gate_kinds_t::t, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, b, hl);
+				dest.add_gate(gate_kinds_t::t_dagger, hl);
+				dest.add_gate(gate_kinds_t::hadamard, hl);
+
+				// S-R2-TOF(c3, hl, target)
+				dest.add_gate(gate_kinds_t::hadamard, d);
+				dest.add_controlled_gate(gate_kinds_t::cx, d, hl);
+				dest.add_gate(gate_kinds_t::t_dagger, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, c, hl);
+				dest.add_gate(gate_kinds_t::t, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, d, hl);
+				dest.add_gate(gate_kinds_t::t_dagger, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, c, hl);
+				dest.add_gate(gate_kinds_t::t, hl);
+
+				// R1-TOF^-1(a, b, hl)
+				dest.add_gate(gate_kinds_t::hadamard, hl);
+				dest.add_gate(gate_kinds_t::t, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, b, hl);
+				dest.add_gate(gate_kinds_t::t_dagger, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, a, hl);
+				dest.add_gate(gate_kinds_t::t, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, b, hl);
+				dest.add_gate(gate_kinds_t::t_dagger, hl);
+				dest.add_gate(gate_kinds_t::hadamard, hl);
+
+				// S-R2-TOF^-1(c3, hl, target)
+				dest.add_gate(gate_kinds_t::t_dagger, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, c, hl);
+				dest.add_gate(gate_kinds_t::t, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, d, hl);
+				dest.add_gate(gate_kinds_t::t_dagger, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, c, hl);
+				dest.add_gate(gate_kinds_t::t, hl);
+				dest.add_controlled_gate(gate_kinds_t::cx, d, hl);
+				dest.add_gate(gate_kinds_t::hadamard, d);
+
+				for (auto i = 1u; i < targets.size(); ++i) {
+					dest.add_controlled_gate(gate_kinds_t::cx,
+					                         targets[0],
+					                         targets[i]);
+				}
+			} break;
+			}
+
+			return true;
+		}
+
+		return false;
+	}, 1);
+}
+
+} // namespace tweedledum

--- a/include/tweedledum/io/write_quil.hpp
+++ b/include/tweedledum/io/write_quil.hpp
@@ -6,8 +6,8 @@
 *-----------------------------------------------------------------------------*/
 #pragma once
 
-#include "../networks/netlist.hpp"
 #include "../networks/gates/gate_kinds.hpp"
+#include "../networks/netlist.hpp"
 
 #pragma once
 
@@ -24,41 +24,84 @@ void write_quil(Network const& circ, std::ostream& out)
 {
 	circ.foreach_node([&](auto const& n) {
 		auto const& g = n.gate;
-		if (g.kind() != gate_kinds_t::mcx) {
+		switch (g.kind()) {
+		default:
 			std::cerr << "[w] unsupported gate type\n";
 			return true;
-		}
-		std::vector<uint32_t> controls, targets;
-		g.foreach_control([&](auto q) { controls.push_back(q); });
-		g.foreach_target([&](auto q) { targets.push_back(q); });
-		switch (controls.size()) {
-		default:
-			std::cerr << "[w] unsupported control size\n";
+
+		case gate_kinds_t::input:
+		case gate_kinds_t::output:
+			/* ignore */
 			return true;
-		case 0u:
-			for (auto q : targets) {
-				out << fmt::format("X {}\n", q);
+
+		case gate_kinds_t::hadamard: {
+			g.foreach_target(
+			    [&](auto q) { out << fmt::format("H {}\n", q); });
+		} break;
+
+		case gate_kinds_t::pauli_x: {
+			g.foreach_target(
+			    [&](auto q) { out << fmt::format("X {}\n", q); });
+		} break;
+
+		case gate_kinds_t::t: {
+			g.foreach_target(
+			    [&](auto q) { out << fmt::format("T {}\n", q); });
+		} break;
+
+		case gate_kinds_t::t_dagger: {
+			g.foreach_target([&](auto q) {
+				out << fmt::format("RZ(-pi/4) {}\n", q);
+			});
+		} break;
+
+		case gate_kinds_t::cx: {
+			g.foreach_control([&](auto qc) {
+				g.foreach_target([&](auto qt) {
+					out << fmt::format("CNOT {} {}\n", qc,
+					                   qt);
+				});
+			});
+		} break;
+
+		case gate_kinds_t::mcx: {
+			std::vector<uint32_t> controls, targets;
+			g.foreach_control([&](auto q) { controls.push_back(q); });
+			g.foreach_target([&](auto q) { targets.push_back(q); });
+			switch (controls.size()) {
+			default:
+				std::cerr << "[w] unsupported control size\n";
+				return true;
+			case 0u:
+				for (auto q : targets) {
+					out << fmt::format("X {}\n", q);
+				}
+				break;
+			case 1u:
+				for (auto q : targets) {
+					out << fmt::format("CNOT {} {}\n",
+					                   controls[0], q);
+				}
+				break;
+			case 2u:
+				for (auto i = 1u; i < targets.size(); ++i) {
+					out << fmt::format("CNOT {} {}\n",
+					                   targets[0],
+					                   targets[i]);
+				}
+				out << fmt::format("CCNOT {} {} {}\n",
+				                   controls[0], controls[1],
+				                   targets[0]);
+				for (auto i = 1u; i < targets.size(); ++i) {
+					out << fmt::format("CNOT {} {}\n",
+					                   targets[0],
+					                   targets[i]);
+				}
+				break;
 			}
-			break;
-		case 1u:
-			for (auto q : targets) {
-				out << fmt::format("CNOT {} {}\n", controls[0],
-				                   q);
-			}
-			break;
-		case 2u:
-			for (auto i = 1u; i < targets.size(); ++i) {
-				out << fmt::format("CNOT {} {}\n", targets[0],
-				                   targets[i]);
-			}
-			out << fmt::format("CCNOT {} {} {}\n", controls[0],
-			                   controls[1], targets[0]);
-			for (auto i = 1u; i < targets.size(); ++i) {
-				out << fmt::format("CNOT {} {}\n", targets[0],
-				                   targets[i]);
-			}
-			break;
+		} break;
 		}
+
 		return true;
 	});
 }

--- a/include/tweedledum/networks/dag_path.hpp
+++ b/include/tweedledum/networks/dag_path.hpp
@@ -9,6 +9,8 @@
 #include "detail/storage.hpp"
 #include "gates/gate_kinds.hpp"
 
+#include <fmt/format.h>
+
 #include <array>
 #include <limits>
 #include <memory>
@@ -51,6 +53,11 @@ public:
 		return storage_->nodes.size() + storage_->outputs.size();
 	}
 
+	uint32_t num_gates() const
+	{
+		return storage_->nodes.size() - storage_->inputs.size();
+	}
+
 	uint32_t num_qubits() const
 	{
 		return storage_->inputs.size();
@@ -61,7 +68,8 @@ public:
 		return storage_->nodes[node_ptr.index];
 	}
 
-	std::vector<node_ptr_type> get_children(node_type const& node, uint32_t qubit_id)
+	std::vector<node_ptr_type> get_children(node_type const& node,
+	                                        uint32_t qubit_id)
 	{
 		std::vector<node_ptr_type> ret;
 		auto input_id = node.gate.get_input_id(qubit_id);
@@ -77,11 +85,18 @@ public:
 		return ret;
 	}
 
-	void add_qubit(std::string const& qubit)
+	auto allocate_qubit()
+	{
+		auto str = fmt::format("q{}", storage_->inputs.size());
+		return add_qubit(str);
+	}
+
+	auto add_qubit(std::string const& qubit)
 	{
 		auto qubit_id = create_qubit();
 		label_to_id_.emplace(qubit, qubit_id);
 		id_to_label_.emplace_back(qubit);
+		return qubit_id;
 	}
 
 	void mark_as_input(std::string const& qubit)

--- a/include/tweedledum/networks/gates/mct_gate.hpp
+++ b/include/tweedledum/networks/gates/mct_gate.hpp
@@ -28,6 +28,11 @@ struct mct_gate {
 		return __builtin_popcount(controls);
 	}
 
+	auto num_targets() const
+	{
+		return __builtin_popcount(targets);
+	}
+
 	template<typename Fn>
 	void foreach_control(Fn&& fn) const
 	{
@@ -46,6 +51,11 @@ struct mct_gate {
 				fn(j);
 			}
 		}
+	}
+
+	bool is(gate_kinds_t kind) const
+	{
+		return kind == gate_kinds_t::mcx;
 	}
 
 	gate_kinds_t kind() const

--- a/include/tweedledum/networks/netlist.hpp
+++ b/include/tweedledum/networks/netlist.hpp
@@ -71,6 +71,13 @@ public:
 		}
 	}
 
+	node_type& add_gate(gate_type const& g)
+	{
+		auto& n = nodes_.emplace_back();
+		n.gate = g;
+		return n;
+	}
+
 	node_type& add_toffoli(uint32_t controls, uint32_t targets)
 	{
 		auto& n = nodes_.emplace_back();


### PR DESCRIPTION
This PR partly unifies the interface, adds a generic rewriting algorithm, and a mapping algorithm for Toffolis up to 3 controls. Also, `write_quil` is extended to support more quantum gates.