### PR TITLE
Revert "extract_term."

### DIFF
--- a/include/tweedledum/utils/parity_terms.hpp
+++ b/include/tweedledum/utils/parity_terms.hpp
@@ -62,12 +62,11 @@ public:
 	/*! \brief Extract parity term. */
 	auto extract_term(uint32_t term)
 	{
-		auto it = term_to_angle_.find(term);
-		if (it == term_to_angle_.end()) {
+		auto node_handle = term_to_angle_.extract(term);
+		if (node_handle.empty()) {
 			return angle(0.0);
-		} else {
-			return it->second;
 		}
+		return node_handle.mapped();
 	}
 #pragma endregion
 


### PR DESCRIPTION
Reverts boschmitt/tweedledum#8

Here, the intended behavior is to actively extract the term from the mapping. If the intention is to only find it and return it, then a new method must be created.