### PR TITLE
Improve write unicode

### DIFF
--- a/include/tweedledum/io/write_unicode.hpp
+++ b/include/tweedledum/io/write_unicode.hpp
@@ -1,12 +1,13 @@
 /*--------------------------------------------------------------------------------------------------
 | This file is distributed under the MIT License.
 | See accompanying file /LICENSE for details.
-| Author(s): Mathias Soeken
+| Author(s): Mathias Soeken, Bruno Schmitt
 *-------------------------------------------------------------------------------------------------*/
 #pragma once
 
 #include "../gates/gate_set.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -14,126 +15,141 @@
 #include <vector>
 
 namespace tweedledum {
+namespace detail {
 
-/*! \brief Creates a Unicode string that represent the network
- *
- * **Required gate functions:**
- * - `op`
- * - `foreach_control`
- * - `foreach_target`
- *
- * **Required network functions:**
- * - `foreach_cgate`
- * - `num_qubits`
- *
- * \param network A quantum network
- * \return A string representing the network using Unicode characters
- */
-template<class Network>
-std::string to_unicode_str(Network const& network)
-{
-	std::vector<std::string> lines(network.num_qubits(), "―");
+class string_builder {
+public:
+	string_builder(uint32_t num_qubits)
+	    : occupancy_(num_qubits, 0)
+	    , lines_(3 * num_qubits, "     ")
+	{
+		for (auto i = 0u; i < num_qubits; ++i) {
+			lines_[(3 * i) + 1].replace(0, 5, "|0>──");
+		}
+	}
 
-	network.foreach_cgate([&](auto const& node) {
-		auto const& gate = node.gate;
-		switch (gate.operation()) {
-		default:
-			gate.foreach_target([&](auto qid) { lines[qid] += "?"; });
-			return;
+	void add_gate(std::string const& op, qubit_id target)
+	{
+		if (occupancy_[target] != 0) {
+			new_column();
+		}
+		occupancy_[target] = 1;
 
-		case gate_set::identity:
-			gate.foreach_target([&](auto qid) { lines[qid] += "I"; });
-			break;
+		lines_[(3 * target)] += "┌───┐";
+		lines_[(3 * target) + 1] += "┤ " + op + " ├";
+		lines_[(3 * target) + 2] += "└───┘";
+	}
 
-		case gate_set::hadamard:
-			gate.foreach_target([&](auto qid) { lines[qid] += "H"; });
-			break;
+	void add_gate(std::string const& op, qubit_id control, qubit_id target)
+	{
+		if (!is_last_column_empty()) {
+			new_column();
+		}
+		occupancy_[control] = 1;
+		occupancy_[target] = 1;
 
-		case gate_set::pauli_x:
-			gate.foreach_target([&](auto qid) { lines[qid] += "X"; });
-			break;
+		lines_[(3 * control)] += control < target ? "     " : "  │  ";
+		lines_[(3 * control) + 1] += control.is_complemented() ? "──◯──" : "──●──";
+		lines_[(3 * control) + 2] += control < target ? "  │  " : "     ";
 
-		case gate_set::pauli_y:
-			gate.foreach_target([&](auto qid) { lines[qid] += "Y"; });
-			break;
+		lines_[(3 * target)] += control < target ? "┌─┴─┐" : "┌───┐";
+		lines_[(3 * target) + 1] += "┤ " + op + " ├";
+		lines_[(3 * target) + 2] += control < target ? "└───┘" : "└─┬─┘";
 
-		case gate_set::pauli_z:
-			gate.foreach_target([&](auto qid) { lines[qid] += "Z"; });
-			break;
+		auto const min = std::min(control.index(), target.index());
+		auto const max = std::max(control.index(), target.index());
+		for (auto i = min + 1; i < max; ++i) {
+			occupancy_[i] = 1;
+			lines_[(3 * i)] += "  │  ";
+			lines_[(3 * i) + 1] += "──┼──";
+			lines_[(3 * i) + 2] += "  │  ";
+		}
+		new_column();
+	}
 
-		case gate_set::rotation_x:
-			gate.foreach_target([&](auto qid) { lines[qid] += "x"; });
-			break;
-
-		case gate_set::rotation_y:
-			gate.foreach_target([&](auto qid) { lines[qid] += "y"; });
-			break;
-
-		case gate_set::rotation_z:
-			gate.foreach_target([&](auto qid) { lines[qid] += "z"; });
-			break;
-
-		case gate_set::phase:
-			gate.foreach_target([&](auto qid) { lines[qid] += "S"; });
-			break;
-
-		case gate_set::phase_dagger:
-			gate.foreach_target([&](auto qid) { lines[qid] += "Ƨ"; });
-			break;
-
-		case gate_set::t:
-			gate.foreach_target([&](auto qid) { lines[qid] += "T"; });
-			break;
-
-		case gate_set::t_dagger:
-			gate.foreach_target([&](auto qid) { lines[qid] += "⊥"; });
-			break;
-
-		case gate_set::cx:
-		case gate_set::mcx:
-			gate.foreach_control([&](auto qid_control) { 
-				if (qid_control.is_complemented()) {
-					lines[qid_control] += "○";
-				} else {
-					lines[qid_control] += "●";
-				}
-			});
-			gate.foreach_target([&](auto qid_target) { lines[qid_target] += "⊕"; });
-			break;
-
-		case gate_set::cz:
-		case gate_set::mcz:
-			gate.foreach_control([&](auto qid_control) { 
-				if (qid_control.is_complemented()) {
-					lines[qid_control] += "○";
-				} else {
-					lines[qid_control] += "●";
-				}
-			});
-			gate.foreach_target([&](auto qid_target) { lines[qid_target] += "Z"; });
-			break;
+	void add_gate(std::string const& op, std::vector<qubit_id> controls,
+	              std::vector<qubit_id> targets)
+	{
+		if (!is_last_column_empty()) {
+			new_column();
 		}
 
-		for (auto& line : lines) {
-			if (line.size() % 2 == 0) {
-				line += "―";
-			} else {
-				line += "――";
+		const auto [min_target, max_target] = std::minmax_element(targets.begin(),
+		                                                          targets.end());
+		const auto [min_control, max_control] = std::minmax_element(controls.begin(),
+		                                                            controls.end());
+		const auto min = std::min(*min_control, *min_target);
+		const auto max = std::max(*max_control, *max_target);
+
+		for (auto control : controls) {
+			occupancy_[control] = 1;
+			lines_[(3 * control)] += control == min ? "     " : "  │  ";
+			lines_[(3 * control) + 1] += control.is_complemented() ? "──◯──" : "──●──";
+			lines_[(3 * control) + 2] += control == max ? "     " : "  │  ";
+		}
+		for (auto target : targets) {
+			occupancy_[target] = 1;
+			lines_[(3 * target)] += target == min ? "┌───┐" : "┌─┴─┐";
+			lines_[(3 * target) + 1] += "┤ " + op + " ├";
+			lines_[(3 * target) + 2] += target == max ? "└───┘" : "└─┬─┘";
+		}
+
+		for (auto i = min.index() + 1; i < max.index(); ++i) {
+			if (occupancy_[i] == 1) {
+				continue;
+			}
+			occupancy_[i] = 1;
+			lines_[(3 * i)] += "  │  ";
+			lines_[(3 * i) + 1] += "──┼──";
+			lines_[(3 * i) + 2] += "  │  ";
+		}
+		new_column();
+	}
+
+	friend std::ostream& operator<<(std::ostream& out, string_builder builder)
+	{
+		std::string result;
+		for (auto const& line : builder.lines_) {
+			result += line + "\n";
+		}
+		out << result;
+		return out;
+	}
+
+private:
+	void new_column()
+	{
+		for (auto i = 0u; i < occupancy_.size(); ++i) {
+			if (occupancy_[i] == 0) {
+				lines_[(3 * i)] += "     ";
+				lines_[(3 * i) + 1] += "─────";
+				lines_[(3 * i) + 2] += "     ";
+			}
+			occupancy_[i] = 0;
+		}
+	}
+
+	bool is_last_column_empty()
+	{
+		for (auto element : occupancy_) {
+			if (element == 1) {
+				return false;
 			}
 		}
-	});
-
-	std::string result;
-	for (auto const& line : lines) {
-		result += line + "\n";
+		return true;
 	}
-	return result;
-}
+
+private:
+	std::vector<uint8_t> occupancy_;
+	std::vector<std::string> lines_;
+};
+
+} // namespace detail
 
 /*! \brief Writes a network in Unicode format format into a output stream
  *
  * **Required gate functions:**
- * - `op`
+ * - `operation`
  * - `foreach_control`
  * - `foreach_target`
  *
@@ -147,14 +163,103 @@ std::string to_unicode_str(Network const& network)
 template<typename Network>
 void write_unicode(Network const& network, std::ostream& os = std::cout)
 {
-	auto unicode_str = to_unicode_str(network);
-	os << unicode_str;
+	if (network.num_gates() == 0) {
+		return;
+	}
+
+	detail::string_builder builder(network.num_qubits());
+	network.foreach_cgate([&](auto const& node) {
+		auto const& gate = node.gate;
+		switch (gate.operation()) {
+		default:
+			std::cerr << "[w] unsupported gate type\n";
+			return true;
+
+		case gate_set::hadamard:
+			gate.foreach_target([&](auto qid) { builder.add_gate("H", qid); });
+			break;
+
+		case gate_set::pauli_x:
+			gate.foreach_target([&](auto qid) { builder.add_gate("X", qid); });
+			break;
+
+		case gate_set::pauli_y:
+			gate.foreach_target([&](auto qid) { builder.add_gate("Y", qid); });
+			break;
+
+		case gate_set::pauli_z:
+			gate.foreach_target([&](auto qid) { builder.add_gate("Z", qid); });
+			break;
+
+		case gate_set::rotation_x:
+			gate.foreach_target([&](auto qid) { builder.add_gate("x", qid); });
+			break;
+
+		case gate_set::rotation_y:
+			gate.foreach_target([&](auto qid) { builder.add_gate("y", qid); });
+			break;
+
+		case gate_set::rotation_z:
+			gate.foreach_target([&](auto qid) { builder.add_gate("z", qid); });
+			break;
+
+		case gate_set::phase:
+			gate.foreach_target([&](auto qid) { builder.add_gate("S", qid); });
+			break;
+
+		case gate_set::phase_dagger:
+			gate.foreach_target([&](auto qid) { builder.add_gate("Ƨ", qid); });
+			break;
+
+		case gate_set::t:
+			gate.foreach_target([&](auto qid) { builder.add_gate("T", qid); });
+			break;
+
+		case gate_set::t_dagger:
+			gate.foreach_target([&](auto qid) { builder.add_gate("⊥", qid); });
+			break;
+
+		case gate_set::cx:
+			gate.foreach_control([&](auto qid_control) {
+				gate.foreach_target([&](auto qid_target) {
+					builder.add_gate("X", qid_control, qid_target);
+				});
+			});
+			break;
+
+		case gate_set::mcx: {
+			std::vector<qubit_id> controls;
+			std::vector<qubit_id> targets;
+			gate.foreach_control([&](auto control) { controls.push_back(control); });
+			gate.foreach_target([&](auto target) { targets.push_back(target); });
+			builder.add_gate("X", controls, targets);
+		} break;
+
+		case gate_set::cz:
+			gate.foreach_control([&](auto qid_control) {
+				gate.foreach_target([&](auto qid_target) {
+					builder.add_gate("Z", qid_control, qid_target);
+				});
+			});
+			break;
+
+		case gate_set::mcz: {
+			std::vector<qubit_id> controls;
+			std::vector<qubit_id> targets;
+			gate.foreach_control([&](auto control) { controls.push_back(control); });
+			gate.foreach_target([&](auto target) { targets.push_back(target); });
+			builder.add_gate("Z", controls, targets);
+		} break;
+		}
+		return true;
+	});
+	os << builder;
 }
 
 /*! \brief Writes a network in Unicode format format into a file
  *
  * **Required gate functions:**
- * - `op`
+ * - `operation`
  * - `foreach_control`
  * - `foreach_target`
  *


### PR DESCRIPTION
This PR add a ``fancy`` parameter to the ``write_unicode`` function. This parameter is ``true`` by default and the circuit is printed as:
```
     ┌───┐                    ┌───┐     ┌───┐
|0>──┤ H ├───────◯────●────●──┤ H ├──◯──┤ H ├
     └───┘       │    │    │  └───┘  │  └───┘
     ┌───┐       │    │    │  ┌───┐  │  ┌───┐
|0>──┤ H ├───────●────●────┼──┤ H ├──◯──┤ H ├
     └───┘       │    │    │  └───┘  │  └───┘
     ┌───┐┌───┐  │    │    │  ┌───┐┌─┴─┐┌───┐
|0>──┤ X ├┤ H ├──◯────┼────◯──┤ H ├┤ Z ├┤ H ├
     └───┘└───┘  │    │    │  └───┘└───┘└───┘
     ┌───┐┌───┐┌─┴─┐┌─┴─┐┌─┴─┐          
|0>──┤ X ├┤ H ├┤ X ├┤ X ├┤ X ├──────────
     └───┘└───┘└───┘└───┘└───┘          
```
When ``fancy`` is ``false``, the output is the old representation:

```
―――――H―――――――○―●―●―H―――――○―H―――――
―――――――H―――――●―●―――――H―――○―――H―――
―⊕―――――――H―――○―――○―――――H―Z―――――H―
―――⊕―――――――H―⊕―⊕―⊕―――――――――――――――
```