### PR TITLE
Synthesis of diagonal unitaries

### DIFF
--- a/docs/algorithms/synthesis.rst
+++ b/docs/algorithms/synthesis.rst
@@ -13,6 +13,7 @@ all synthesis algorithms that are currently provided in *tweedledum*.
    synthesis/dbs
    synthesis/tbs
    synthesis/gray_synth
+   synthesis/diagonal_synth
    synthesis/linear_synth
    synthesis/esop_phase_synth
 

--- a/docs/algorithms/synthesis/diagonal_synth.rst
+++ b/docs/algorithms/synthesis/diagonal_synth.rst
@@ -1,0 +1,11 @@
+Synthesis of diagonal unitaries
+-------------------------------
+
+**Header:** :file:`tweedledum/algorithms/synthesis/diagonal_synth.hpp`
+
+Algorithm
+~~~~~~~~~
+
+.. doxygenfunction:: tweedledum::diagonal_synth(std::vector<double> const&)
+
+.. doxygenfunction:: tweedledum::diagonal_synth(Circuit&, std::vector<qubit_id> const&, std::vector<double> const&)

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -81,6 +81,18 @@
 	doi = {10.1109/ISCAS.2016.7539041}
 }
 
+@Article{SS03,
+	author = {Norbert Schuch and Jens Siewert},
+	title = {Programmable networks for quantum algorithms},
+	journal = PRL,
+	volume = {91},
+	number = {2},
+	pages = {027902},
+	year = {2003},
+	url = {https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.91.027902},
+	doi = {10.1103/PhysRevLett.91.027902}
+}
+
 @Article{VR08,
 	author = {De Vos, Alexis and Van Rentergem, Yvan},
 	title = {Young subgroups for reversible computers},

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,6 +1,8 @@
 @String{AMC = "Advances in Mathematics of Communications"}
 @String{DAC = "Design Automation Conference"}
 @String{ISCAS = "Int'l Symp. on Circuits and Systems"}
+@String{PRA = "Physical Review A"}
+@String{PRL = "Physical Review Letters"}
 @String{QIC = "Quantum Information {\&} Computation"}
 @String{TCAD = "IEEE Transactions on Computer-Aided Design of Integrated Circuits and Systems"}
 
@@ -27,7 +29,7 @@
 @Article{Barenco95,
 	title = {Elementary gates for quantum computation},
 	author = {Barenco, Adriano and Bennett, Charles H and Cleve, Richard and DiVincenzo, David P and Margolus, Norman and Shor, Peter and Sleator, Tycho and Smolin, John A and Weinfurter, Harald},
-	journal = {Physical review A},
+	journal = PRA,
 	volume = {52},
 	number = {5},
 	pages = {3457},
@@ -39,7 +41,7 @@
 @Article{Maslov2016,
 	title={Advantages of using relative-phase Toffoli gates with an application to multiple control Toffoli optimization},
 	author={Maslov, Dmitri},
-	journal={Physical Review A},
+	journal=PRA,
 	volume={93},
 	number={2},
 	pages={022311},

--- a/include/tweedledum/algorithms/synthesis/diagonal_synth.hpp
+++ b/include/tweedledum/algorithms/synthesis/diagonal_synth.hpp
@@ -1,0 +1,113 @@
+/*--------------------------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+| Author(s): Mathias Soeken
+*-------------------------------------------------------------------------------------------------*/
+#pragma once
+
+#include "../../networks/qubit.hpp"
+#include "../../utils/parity_terms.hpp"
+#include "gray_synth.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+namespace tweedledum {
+
+namespace detail {
+
+inline void fast_hadamard_transform(std::vector<double>& s)
+{
+	unsigned k{};
+	double t{};
+
+	for (auto m = 1u; m < s.size(); m <<= 1u) {
+		for (auto i = 0u; i < s.size(); i += (m << 1u)) {
+			for (auto j = i, p = k = i + m; j < p; ++j, ++k) {
+				t = s[j];
+				s[j] += s[k];
+				s[k] = t - s[k];
+			}
+		}
+	}
+}
+
+} // namespace detail
+
+/*! \brief Gray synthesis for {CNOT, Rz} networks.
+ *
+ * This is the in-place variant of ``diagonal_synth``, in which the network is
+ * passed as a parameter and can potentially already contain some gates.
+ * The parameter ``qubits`` provides a qubit mapping to the existing qubits in
+ * the network.
+ *
+ * \param circ   A quantum network
+ * \param qubits The subset of qubits the linear reversible circuit acts upon
+ * \param angles Angles for diagonal matrix elements
+ */
+template<class Circuit>
+void diagonal_synth(Circuit& circ, std::vector<qubit_id> const& qubits,
+                    std::vector<double> const& angles)
+{
+	/* there are 2^n - 1 angles */
+	assert(1u << qubits.size() == angles.size() + 1u);
+
+	/* fast Hadamard transform on extended vector */
+	std::vector<double> s(angles.size() + 1, 0.0);
+	std::copy(angles.begin(), angles.end(), s.begin() + 1);
+	detail::fast_hadamard_transform(s);
+
+	const double factor = 1 << (qubits.size() - 1);
+	parity_terms parities;
+	for (uint32_t i = 1u; i < s.size(); ++i) {
+		if (s[i] == 0.0)
+			continue;
+		parities.add_term(i, s[i] / factor);
+	}
+
+	gray_synth(circ, qubits, parities);
+}
+
+/*! \brief Synthesis of diagonal unitary matrices.
+ *
+   \verbatim embed:rst
+
+   This algorithm is based on the work in :cite:`SS03`.  It takes as input
+   :math:`2^n - 1` real angles :math:`\theta_i` for :math:`i = 1, \dots, 2^{n-1}` and
+   returns a quantum circuit that realizes the :math:`2^n \times 2^n` unitary
+   operation
+
+   :math:`U = \mathrm{diag}(1, e^{-\mathrm{i}\theta_1}, e^{-\mathrm{i}\theta_2}, \dots, e^{-\mathrm{i}\theta_{2^{n-1}}}).`
+
+   It uses a fast Hadamard transformation to compute angles for parity terms
+   that are passed to the Gray synthesis algorithm ``gray_synth``.
+   
+   \endverbatim
+ *
+ * \param angles Angles for diagonal matrix elements
+ * 
+ * \return {CNOT, Rz} network
+ *
+ * \algtype synthesis
+ * \algexpects List of angles in diagonal unitary matrix
+ * \algreturns {CNOT, Rz} network
+ */
+template<class Circuit>
+Circuit diagonal_synth(std::vector<double> const& angles)
+{
+	const auto num_qubits = static_cast<uint32_t>(std::log2(angles.size() + 1));
+	assert(1u << num_qubits == angles.size() + 1u);
+	assert(num_qubits <= 32);
+	Circuit circ;
+	for (auto i = 0u; i < num_qubits; ++i) {
+		circ.add_qubit();
+	}
+	std::vector<qubit_id> qubits(num_qubits);
+	std::iota(qubits.begin(), qubits.end(), 0u);
+	diagonal_synth(circ, qubits, angles);
+	return circ;
+}
+
+} // namespace tweedledum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(tweedledum_tests_files
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithms/decomposition/dt.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithms/synthesis/cnot_patel.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithms/synthesis/dbs.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/algorithms/synthesis/diagonal_synth.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithms/synthesis/esop_phase_synth.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithms/synthesis/gray_synth.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/algorithms/synthesis/linear_synth.cpp"

--- a/tests/algorithms/synthesis/diagonal_synth.cpp
+++ b/tests/algorithms/synthesis/diagonal_synth.cpp
@@ -1,0 +1,27 @@
+/*--------------------------------------------------------------------------------------------------
+| This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+| Author(s): Mathias Soeken, Bruno Schmitt
+*-------------------------------------------------------------------------------------------------*/
+#include <catch.hpp>
+#include <sstream>
+#include <tweedledum/algorithms/synthesis/diagonal_synth.hpp>
+#include <tweedledum/gates/mcst_gate.hpp>
+#include <tweedledum/io/quil.hpp>
+#include <tweedledum/networks/netlist.hpp>
+
+TEST_CASE("Synthesize diagonal unitaries", "[diagonal_synth]")
+{
+	using namespace tweedledum;
+
+	std::vector<double> angles = {1.0 / 2, 1.0 / 3, 1.0 / 4};
+	const auto circ = diagonal_synth<netlist<mcst_gate>>(angles);
+	std::stringstream str;
+	write_quil(circ, str);
+	CHECK(str.str() == R"quil(RZ(-0.208333) 0
+RZ(-0.0416667) 1
+CNOT 1 0
+RZ(-0.291667) 0
+CNOT 1 0
+)quil");
+}


### PR DESCRIPTION
This PR uses GraySynth to implement a synthesis algorithm based on [[N. Schuch and J. Siewert, *PRL* **91** (2003), 027902]](https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.91.027902) that finds CNOT+Rz circuits for diagonal unitary matrices.
