### PR TITLE
Improve networks interface

### DIFF
--- a/include/tweedledum/algorithms/generic/rewrite.hpp
+++ b/include/tweedledum/algorithms/generic/rewrite.hpp
@@ -34,7 +34,7 @@ void rewrite_network(NetworkDest& dest, NetworkSrc const& src, RewriteFn&& fn, u
 		if (!fn(dest, node.gate)) {
 			if constexpr (std::is_same_v<typename NetworkSrc::gate_type,
 			                             typename NetworkDest::gate_type>) {
-				dest.add_gate(node.gate);
+				dest.emplace_gate(node.gate);
 			}
 		}
 	});

--- a/include/tweedledum/networks/gg_network.hpp
+++ b/include/tweedledum/networks/gg_network.hpp
@@ -179,8 +179,7 @@ private:
 	node_type& add_gate(gate_base op, std::string const& qlabel_target)
 	{
 		auto qid_target = qlabels_->to_qid(qlabel_target);
-		gate_type gate(op, qid_target);
-		return add_gate(gate);
+		return add_gate(op, qid_target);
 	}
 
 	node_type& add_gate(gate_base op, std::string const& qlabel_control,
@@ -188,8 +187,7 @@ private:
 	{
 		auto qid_control = qlabels_->to_qid(qlabel_control);
 		auto qid_target = qlabels_->to_qid(qlabel_target);
-		gate_type gate(op, qid_control, qid_target);
-		return add_gate(gate);
+		return add_gate(op, qid_control, qid_target);
 	}
 
 	node_type& add_gate(gate_base op, std::vector<std::string> const& qlabels_control,
@@ -203,8 +201,7 @@ private:
 		for (auto& target : qlabels_target) {
 			targets.push_back(qlabels_->to_qid(target));
 		}
-		gate_type gate(op, controls, targets);
-		return add_gate(gate);
+		return add_gate(op, controls, targets);
 	}
 #pragma endregion
 

--- a/include/tweedledum/networks/gg_network.hpp
+++ b/include/tweedledum/networks/gg_network.hpp
@@ -130,11 +130,12 @@ private:
 		return;
 	}
 
-	auto& do_add_gate(gate_type gate)
+public:
+	template<typename... Args>
+	node_type& emplace_gate(Args&&... args)
 	{
 		auto node_index = storage_->nodes.size();
-		auto& node = storage_->nodes.emplace_back(gate);
-
+		auto& node = storage_->nodes.emplace_back(std::forward<Args>(args)...);
 		node.gate.foreach_control([&](auto& qid) { connect_node(qid, node_index); });
 		node.gate.foreach_target([&](auto& qid) { connect_node(qid, node_index); });
 		return node;
@@ -142,24 +143,16 @@ private:
 
 	node_type& add_gate(gate_base op, qubit_id target)
 	{
-		return do_add_gate(gate);
+		return emplace_gate(gate_type(op, storage_->rewiring_map.at(target)));
 	}
 
 	node_type& add_gate(gate_base op, qubit_id control, qubit_id target)
 	{
-		gate_type gate(op, storage_->rewiring_map.at(target));
-		return add_gate(gate);
+		const qubit_id control_(storage_->rewiring_map.at(control), control.is_complemented());
+		return emplace_gate(gate_type(op, control_, storage_->rewiring_map.at(target)));
 	}
 
 	node_type& add_gate(gate_base op, std::vector<qubit_id> controls, std::vector<qubit_id> targets)
-	{
-		gate_type gate(op,
-		               qubit_id(storage_->rewiring_map.at(control), control.is_complemented()),
-		               storage_->rewiring_map.at(target));
-		return add_gate(gate);
-	}
-
-	auto& add_gate(gate_base op, std::vector<qubit_id> controls, std::vector<qubit_id> targets)
 	{
 		std::transform(controls.begin(), controls.end(), controls.begin(),
 		               [&](qubit_id qid) -> qubit_id {
@@ -170,8 +163,7 @@ private:
 		               [&](qubit_id qid) -> qubit_id {
 			               return storage_->rewiring_map.at(qid);
 		               });
-		gate_type gate(op, controls, targets);
-		return add_gate(gate);
+		return emplace_gate(gate_type(op, controls, targets));
 	}
 #pragma endregion
 
@@ -183,7 +175,7 @@ private:
 	}
 
 	node_type& add_gate(gate_base op, std::string const& qlabel_control,
-	               std::string const& qlabel_target)
+	                    std::string const& qlabel_target)
 	{
 		auto qid_control = qlabels_->to_qid(qlabel_control);
 		auto qid_target = qlabels_->to_qid(qlabel_target);
@@ -191,7 +183,7 @@ private:
 	}
 
 	node_type& add_gate(gate_base op, std::vector<std::string> const& qlabels_control,
-	               std::vector<std::string> const& qlabels_target)
+	                    std::vector<std::string> const& qlabels_target)
 	{
 		std::vector<qubit_id> controls;
 		for (auto& control : qlabels_control) {

--- a/include/tweedledum/networks/gg_network.hpp
+++ b/include/tweedledum/networks/gg_network.hpp
@@ -49,7 +49,7 @@ public:
 
 #pragma region I / O and ancillae qubits
 private:
-	auto create_qubit()
+	qubit_id create_qubit()
 	{
 		qubit_id qid(storage_->inputs.size());
 		uint32_t index = storage_->nodes.size();
@@ -67,14 +67,14 @@ private:
 	}
 
 public:
-	auto add_qubit(std::string const& qlabel)
+	qubit_id add_qubit(std::string const& qlabel)
 	{
 		auto qid = create_qubit();
 		qlabels_->map(qid, qlabel);
 		return qid;
 	}
 
-	auto add_qubit()
+	qubit_id add_qubit()
 	{
 		auto qlabel = fmt::format("q{}", storage_->inputs.size());
 		return add_qubit(qlabel);
@@ -82,19 +82,19 @@ public:
 #pragma endregion
 
 #pragma region Structural properties
-	auto size() const
+	uint32_t size() const
 	{
-		return static_cast<uint32_t>(storage_->nodes.size() + storage_->outputs.size());
+		return (storage_->nodes.size() + storage_->outputs.size());
 	}
 
-	auto num_qubits() const
+	uint32_t num_qubits() const
 	{
-		return static_cast<uint32_t>(storage_->inputs.size());
+		return (storage_->inputs.size());
 	}
 
-	auto num_gates() const
+	uint32_t num_gates() const
 	{
-		return static_cast<uint32_t>(storage_->nodes.size() - storage_->inputs.size());
+		return (storage_->nodes.size() - storage_->inputs.size());
 	}
 #pragma endregion
 
@@ -140,19 +140,18 @@ private:
 		return node;
 	}
 
-public:
-	auto& add_gate(gate_type const& gate)
+	node_type& add_gate(gate_base op, qubit_id target)
 	{
 		return do_add_gate(gate);
 	}
 
-	auto& add_gate(gate_base op, qubit_id target)
+	node_type& add_gate(gate_base op, qubit_id control, qubit_id target)
 	{
 		gate_type gate(op, storage_->rewiring_map.at(target));
 		return add_gate(gate);
 	}
 
-	auto& add_gate(gate_base op, qubit_id control, qubit_id target)
+	node_type& add_gate(gate_base op, std::vector<qubit_id> controls, std::vector<qubit_id> targets)
 	{
 		gate_type gate(op,
 		               qubit_id(storage_->rewiring_map.at(control), control.is_complemented()),
@@ -177,14 +176,14 @@ public:
 #pragma endregion
 
 #pragma region Add gates(qlabels)
-	auto& add_gate(gate_base op, std::string const& qlabel_target)
+	node_type& add_gate(gate_base op, std::string const& qlabel_target)
 	{
 		auto qid_target = qlabels_->to_qid(qlabel_target);
 		gate_type gate(op, qid_target);
 		return add_gate(gate);
 	}
 
-	auto& add_gate(gate_base op, std::string const& qlabel_control,
+	node_type& add_gate(gate_base op, std::string const& qlabel_control,
 	               std::string const& qlabel_target)
 	{
 		auto qid_control = qlabels_->to_qid(qlabel_control);
@@ -193,7 +192,7 @@ public:
 		return add_gate(gate);
 	}
 
-	auto& add_gate(gate_base op, std::vector<std::string> const& qlabels_control,
+	node_type& add_gate(gate_base op, std::vector<std::string> const& qlabels_control,
 	               std::vector<std::string> const& qlabels_target)
 	{
 		std::vector<qubit_id> controls;

--- a/include/tweedledum/networks/netlist.hpp
+++ b/include/tweedledum/networks/netlist.hpp
@@ -54,14 +54,14 @@ private:
 	}
 
 public:
-	auto add_qubit(std::string const& qlabel)
+	qubit_id add_qubit(std::string const& qlabel)
 	{
 		auto qid = create_qubit();
 		qlabels_->map(qid, qlabel);
 		return qid;
 	}
 
-	auto add_qubit()
+	qubit_id add_qubit()
 	{
 		auto qlabel = fmt::format("q{}", storage_->inputs.size());
 		return add_qubit(qlabel);
@@ -69,19 +69,19 @@ public:
 #pragma endregion
 
 #pragma region Structural properties
-	auto size() const
+	uint32_t size() const
 	{
-		return static_cast<uint32_t>(storage_->nodes.size() + storage_->outputs.size());
+		return (storage_->nodes.size() + storage_->outputs.size());
 	}
 
-	auto num_qubits() const
+	uint32_t num_qubits() const
 	{
-		return static_cast<uint32_t>(storage_->inputs.size());
+		return (storage_->inputs.size());
 	}
 
-	auto num_gates() const
+	uint32_t num_gates() const
 	{
-		return static_cast<uint32_t>(storage_->nodes.size() - storage_->inputs.size());
+		return (storage_->nodes.size() - storage_->inputs.size());
 	}
 #pragma endregion
 
@@ -119,13 +119,13 @@ public:
 		return node;
 	}
 
-	auto& add_gate(gate_base op, qubit_id target)
+	node_type& add_gate(gate_base op, qubit_id target)
 	{
 		gate_type gate(op, storage_->rewiring_map.at(target));
 		return add_gate(gate);
 	}
 
-	auto& add_gate(gate_base op, qubit_id control, qubit_id target)
+	node_type& add_gate(gate_base op, qubit_id control, qubit_id target)
 	{
 		gate_type gate(op,
 		               qubit_id(storage_->rewiring_map.at(control), control.is_complemented()),
@@ -133,7 +133,7 @@ public:
 		return add_gate(gate);
 	}
 
-	auto& add_gate(gate_base op, std::vector<qubit_id> controls, std::vector<qubit_id> targets)
+	node_type& add_gate(gate_base op, std::vector<qubit_id> controls, std::vector<qubit_id> targets)
 	{
 		std::transform(controls.begin(), controls.end(), controls.begin(),
 		               [&](qubit_id qid) -> qubit_id {
@@ -150,14 +150,14 @@ public:
 #pragma endregion
 
 #pragma region Add gates(qlabels)
-	auto& add_gate(gate_base op, std::string const& qlabel_target)
+	node_type& add_gate(gate_base op, std::string const& qlabel_target)
 	{
 		auto qid_target = qlabels_->to_qid(qlabel_target);
 		gate_type gate(op, qid_target);
 		return add_gate(gate);
 	}
 
-	auto& add_gate(gate_base op, std::string const& qlabel_control,
+	node_type& add_gate(gate_base op, std::string const& qlabel_control,
 	               std::string const& qlabel_target)
 	{
 		auto qid_control = qlabels_->to_qid(qlabel_control);
@@ -166,7 +166,7 @@ public:
 		return add_gate(gate);
 	}
 
-	auto& add_gate(gate_base op, std::vector<std::string> const& qlabels_control,
+	node_type& add_gate(gate_base op, std::vector<std::string> const& qlabels_control,
 	               std::vector<std::string> const& qlabels_target)
 	{
 		std::vector<qubit_id> controls;

--- a/include/tweedledum/networks/netlist.hpp
+++ b/include/tweedledum/networks/netlist.hpp
@@ -153,8 +153,7 @@ public:
 	node_type& add_gate(gate_base op, std::string const& qlabel_target)
 	{
 		auto qid_target = qlabels_->to_qid(qlabel_target);
-		gate_type gate(op, qid_target);
-		return add_gate(gate);
+		return add_gate(op, qid_target);
 	}
 
 	node_type& add_gate(gate_base op, std::string const& qlabel_control,
@@ -162,8 +161,7 @@ public:
 	{
 		auto qid_control = qlabels_->to_qid(qlabel_control);
 		auto qid_target = qlabels_->to_qid(qlabel_target);
-		gate_type gate(op, qid_control, qid_target);
-		return add_gate(gate);
+		return add_gate(op, qid_control, qid_target);
 	}
 
 	node_type& add_gate(gate_base op, std::vector<std::string> const& qlabels_control,
@@ -177,8 +175,7 @@ public:
 		for (auto& target : qlabels_target) {
 			targets.push_back(qlabels_->to_qid(target));
 		}
-		gate_type gate(op, controls, targets);
-		return add_gate(gate);
+		return add_gate(op, controls, targets);
 	}
 #pragma endregion
 


### PR DESCRIPTION
This PR cleanup a bit of 'auto' abuse; It fixes a bug when adding gates using qubit labels: when adding gates using those functions the possibility of rewiring was not being taken into account. It also adds a new function 'emplace_gate' which forward arguments. 

CAUTION: when emplacing a new gate, the network assumes the user took rewire into consideration.