### PR TITLE
Output full floating point precision for quil and qasm

### DIFF
--- a/include/tweedledum/io/qasm.hpp
+++ b/include/tweedledum/io/qasm.hpp
@@ -79,17 +79,17 @@ void write_qasm(Network const& network, std::ostream& os)
 
 		case gate_set::rotation_z:
 			gate.foreach_target([&](auto target) {
-				os << fmt::format("rz({.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
+				os << fmt::format("rz({:.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
 			});
 			break;
 		case gate_set::rotation_y:
 			gate.foreach_target([&](auto target) {
-				os << fmt::format("ry({.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
+				os << fmt::format("ry({:.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
 			});
 			break;
 		case gate_set::rotation_x:
 			gate.foreach_target([&](auto target) {
-				os << fmt::format("rx({.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
+				os << fmt::format("rx({:.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
 			});
 			break;
 

--- a/include/tweedledum/io/qasm.hpp
+++ b/include/tweedledum/io/qasm.hpp
@@ -79,17 +79,17 @@ void write_qasm(Network const& network, std::ostream& os)
 
 		case gate_set::rotation_z:
 			gate.foreach_target([&](auto target) {
-				os << fmt::format("rz({}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
+				os << fmt::format("rz({.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
 			});
 			break;
 		case gate_set::rotation_y:
 			gate.foreach_target([&](auto target) {
-				os << fmt::format("ry({}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
+				os << fmt::format("ry({.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
 			});
 			break;
 		case gate_set::rotation_x:
 			gate.foreach_target([&](auto target) {
-				os << fmt::format("rx({}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
+				os << fmt::format("rx({.17f}) q[{}];\n", gate.rotation_angle().numeric_value(), target);
 			});
 			break;
 

--- a/include/tweedledum/io/quil.hpp
+++ b/include/tweedledum/io/quil.hpp
@@ -73,7 +73,7 @@ void write_quil(Network const& network, std::ostream& os)
 
 		case gate_set::rotation_z:
 			gate.foreach_target([&](auto target) {
-				os << fmt::format("RZ({}) {}\n", gate.rotation_angle().numeric_value(), target);
+				os << fmt::format("RZ({:.17f}) {}\n", gate.rotation_angle().numeric_value(), target);
 			});
 			break;
 


### PR DESCRIPTION
I'm not convinced this is the best solution. But it's a jumping-off point.

This was prompted by tweedledum outputting pi with only 6 digits of precision, which is not great. I think the best solution would be to, where possible, output a symbolic representation which the quil compiler certainly understands (not sure about qasm).