### PR TITLE
Don't use C++17's unordered_map::extract()

### DIFF
--- a/include/tweedledum/utils/parity_terms.hpp
+++ b/include/tweedledum/utils/parity_terms.hpp
@@ -62,11 +62,12 @@ public:
 	/*! \brief Extract parity term. */
 	auto extract_term(uint32_t term)
 	{
-		auto node_handle = term_to_angle_.extract(term);
-		if (node_handle.empty()) {
+		auto search = term_to_angle_.find(term);
+		if (search != term_to_angle_.end()) {
+			return search->second;
+		} else {
 			return angle(0.0);
 		}
-		return node_handle.mapped();
 	}
 #pragma endregion
 

--- a/include/tweedledum/utils/parity_terms.hpp
+++ b/include/tweedledum/utils/parity_terms.hpp
@@ -64,6 +64,7 @@ public:
 	{
 		auto search = term_to_angle_.find(term);
 		if (search != term_to_angle_.end()) {
+			term_to_angle_.erase(search);
 			return search->second;
 		} else {
 			return angle(0.0);


### PR DESCRIPTION
With this change I can target standard g++ installations (even the default macos version) with just `-std=c++17`.