### PR TITLE
Fix `setup.py` to correctly build python wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 setup(
     name="tweedledum",
-    version="1.0.0-beta2",
+    version="1.0.0-beta1",
     description="A library for synthesizing and manipulating quantum circuits",
     url="https://github.com/boschmitt/tweedledum",
     author='Bruno Schmitt',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 # See accompanying file /LICENSE for details.
 #-------------------------------------------------------------------------------
 import sys
+import setuptools
 
 try:
     from skbuild import setup
@@ -22,7 +23,7 @@ setup(
     author_email='bruno.schmitt@epfl.ch',
     license="MIT",
     package_dir={'': 'python'},
-    packages=['tweedledum'],
+    packages=setuptools.find_packages(where='python'),
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except ImportError:
 
 setup(
     name="tweedledum",
-    version="1.0.0-beta0",
+    version="1.0.0-beta2",
     description="A library for synthesizing and manipulating quantum circuits",
     url="https://github.com/boschmitt/tweedledum",
     author='Bruno Schmitt',


### PR DESCRIPTION
The previous wheels were shipping with only the C++ module.