### PR TITLE
Refactor wires

### DIFF
--- a/include/tweedledum/Generators/adder.h
+++ b/include/tweedledum/Generators/adder.h
@@ -24,14 +24,14 @@ namespace deprecated {
 // This is a literal translation of the algorithm given in Figure 5 of the
 // Cuccaro et al. paper.
 inline void carry_ripple_adder_inplace_cdkm(Circuit& circuit,
-    std::vector<WireRef> const& a, std::vector<WireRef> const& b, WireRef carry)
+    std::vector<Qubit> const& a, std::vector<Qubit> const& b, Qubit carry)
 {
     assert(a.size() == b.size());
     uint32_t const n = a.size();
     for (uint32_t i = 1; i < n; ++i) {
         circuit.apply_operator(Op::X(), {a[i], b[i]});
     }
-    WireRef x = circuit.request_ancilla();
+    Qubit x = circuit.request_ancilla();
     circuit.apply_operator(Op::X(), {a[1], x});
     circuit.apply_operator(Op::X(), {a[0], b[0], x});
     circuit.apply_operator(Op::X(), {a[2], a[1]});
@@ -78,14 +78,14 @@ inline void carry_ripple_adder_inplace_cdkm(Circuit& circuit,
 // Cuccaro et al. paper.  The only difference here is that the inversters are
 // absorbed into the the controls of the Toffoli gates.
 inline void carry_ripple_adder_inplace_cdkm(Circuit& circuit,
-    std::vector<WireRef> const& a, std::vector<WireRef> const& b, WireRef carry)
+    std::vector<Qubit> const& a, std::vector<Qubit> const& b, Qubit carry)
 {
     assert(a.size() == b.size());
     uint32_t const n = a.size();
     for (uint32_t i = 1; i < n; ++i) {
         circuit.apply_operator(Op::X(), {a[i], b[i]});
     }
-    WireRef x = circuit.request_ancilla();
+    Qubit x = circuit.request_ancilla();
     circuit.apply_operator(Op::X(), {a[1], x});
     circuit.apply_operator(Op::X(), {a[0], b[0], x});
     circuit.apply_operator(Op::X(), {a[2], a[1]});
@@ -122,11 +122,11 @@ inline void carry_ripple_adder_inplace_cdkm(Circuit& circuit,
 
 // This is an implementation based on Figure 4 of the Cuccaro et al. paper.
 inline void carry_ripple_adder_inplace_cdkm_v1(Circuit& circuit,
-    std::vector<WireRef> const& a, std::vector<WireRef> const& b, WireRef carry)
+    std::vector<Qubit> const& a, std::vector<Qubit> const& b, Qubit carry)
 {
     assert(a.size() == b.size());
     uint32_t const n = a.size();
-    WireRef x = circuit.request_ancilla();
+    Qubit x = circuit.request_ancilla();
     // MAJ(x, b0, a0)
     circuit.apply_operator(Op::X(), {a[0], b[0]});
     circuit.apply_operator(Op::X(), {a[0], x});
@@ -152,7 +152,7 @@ inline void carry_ripple_adder_inplace_cdkm_v1(Circuit& circuit,
 
 // Ripple-Carry approach with depth O(n)
 inline void carry_ripple_adder_inplace_ttk(Circuit& circuit,
-    std::vector<WireRef> a, std::vector<WireRef> const& b, WireRef carry)
+    std::vector<Qubit> a, std::vector<Qubit> const& b, Qubit carry)
 {
     assert(a.size() == b.size());
     uint32_t const n = a.size();
@@ -187,7 +187,7 @@ inline void carry_ripple_adder_inplace_ttk(Circuit& circuit,
 
 // Generic function that takes the adder I think is best (:
 inline void carry_ripple_adder_inplace(Circuit& circuit,
-    std::vector<WireRef> const& a, std::vector<WireRef> const& b, WireRef carry)
+    std::vector<Qubit> const& a, std::vector<Qubit> const& b, Qubit carry)
 {
     carry_ripple_adder_inplace_ttk(circuit, a, b, carry);
 }
@@ -195,15 +195,15 @@ inline void carry_ripple_adder_inplace(Circuit& circuit,
 inline Circuit carry_ripple_adder_inplace(uint32_t n)
 {
     Circuit circuit;
-    std::vector<WireRef> a_qubits;
-    std::vector<WireRef> b_qubits;
+    std::vector<Qubit> a_qubits;
+    std::vector<Qubit> b_qubits;
     for (uint32_t i = 0; i < n; ++i) {
         a_qubits.push_back(circuit.create_qubit(fmt::format("a{}", i)));
     }
     for (uint32_t i = 0; i < n; ++i) {
         b_qubits.push_back(circuit.create_qubit(fmt::format("b{}", i)));
     }
-    WireRef carry = circuit.create_qubit();
+    Qubit carry = circuit.create_qubit();
     carry_ripple_adder_inplace_ttk(circuit, a_qubits, b_qubits, carry);
     return circuit;
 }

--- a/include/tweedledum/Generators/less_than.h
+++ b/include/tweedledum/Generators/less_than.h
@@ -21,11 +21,11 @@ namespace deprecated {
 // Implementation based on TTK ripple carry adder.  This basically just make 
 // a one complement by adding inverters (NOT) gates.
 inline void less_than_ttk(Circuit& circuit,
-    std::vector<WireRef> a, std::vector<WireRef> const& b, WireRef lt)
+    std::vector<Qubit> a, std::vector<Qubit> const& b, Qubit lt)
 {
     assert(a.size() == b.size());
     uint32_t const n = a.size();
-    for (WireRef w : a) {
+    for (Qubit w : a) {
         circuit.apply_operator(Op::X(), {w});
     }
     a.push_back(lt);
@@ -62,7 +62,7 @@ inline void less_than_ttk(Circuit& circuit,
 // This is a slightly better version.  The only difference here is that the 
 // inversters are absorbed into the the controls of the Toffoli gates.
 inline void less_than_ttk(Circuit& circuit,
-    std::vector<WireRef> a, std::vector<WireRef> const& b, WireRef lt)
+    std::vector<Qubit> a, std::vector<Qubit> const& b, Qubit lt)
 {
     assert(a.size() == b.size());
     uint32_t const n = a.size();
@@ -100,7 +100,7 @@ inline void less_than_ttk(Circuit& circuit,
 
 // Generic function that takes the one I think is best (:
 inline void less_than(Circuit& circuit,
-    std::vector<WireRef> const& a, std::vector<WireRef> const& b, WireRef carry)
+    std::vector<Qubit> const& a, std::vector<Qubit> const& b, Qubit carry)
 {
     less_than_ttk(circuit, a, b, carry);
 }
@@ -108,15 +108,15 @@ inline void less_than(Circuit& circuit,
 inline Circuit less_than(uint32_t n)
 {
     Circuit circuit;
-    std::vector<WireRef> a_qubits;
-    std::vector<WireRef> b_qubits;
+    std::vector<Qubit> a_qubits;
+    std::vector<Qubit> b_qubits;
     for (uint32_t i = 0; i < n; ++i) {
         a_qubits.push_back(circuit.create_qubit(fmt::format("a{}", i)));
     }
     for (uint32_t i = 0; i < n; ++i) {
         b_qubits.push_back(circuit.create_qubit(fmt::format("b{}", i)));
     }
-    WireRef carry = circuit.create_qubit();
+    Qubit carry = circuit.create_qubit();
     less_than(circuit, a_qubits, b_qubits, carry);
     return circuit;
 }

--- a/include/tweedledum/IR/Cbit.h
+++ b/include/tweedledum/IR/Cbit.h
@@ -1,0 +1,90 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#pragma once
+
+#include <cassert>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace tweedledum {
+
+class WireStorage;
+
+class Cbit {
+public:
+    enum Polarity : uint32_t {
+        positive = 0u, 
+        negative = 1u 
+    };
+
+    // Return the sentinel value
+    static constexpr Cbit invalid()
+    {
+        return Cbit();
+    }
+
+    Cbit(Cbit const& other) = default;
+
+    Cbit& operator=(Cbit const& other)
+    {
+        data_ = other.data_;
+        return *this;
+    }
+
+    uint32_t uid() const
+    {
+        return uid_;
+    }
+
+    Polarity polarity() const
+    {
+        return static_cast<Polarity>(polarity_);
+    }
+
+    Cbit operator!() const
+    {
+        Cbit complemented(*this);
+        complemented.polarity_ ^= 1u;
+        return complemented;
+    }
+
+    bool operator==(Cbit other) const
+    {
+        return data_ == other.data_;
+    }
+
+    bool operator!=(Cbit other) const
+    {
+        return data_ != other.data_;
+    }
+
+    operator uint32_t() const
+    {
+        return uid_;
+    }
+
+protected:
+    friend class WireStorage;
+
+    constexpr Cbit(uint32_t uid, Polarity polarity = Polarity::positive)
+        : uid_(uid), polarity_(static_cast<uint32_t>(polarity))
+    {}
+
+    union {
+        uint32_t data_;
+        struct {
+            uint32_t uid_ : 31;
+            uint32_t polarity_ : 1;
+        };
+    };
+
+private:
+    constexpr Cbit()
+        : data_(std::numeric_limits<uint32_t>::max())
+    {}
+};
+
+} // namespace tweedledum

--- a/include/tweedledum/IR/Circuit.h
+++ b/include/tweedledum/IR/Circuit.h
@@ -49,7 +49,8 @@ public:
     // Wires
     WireRef create_qubit(std::string_view name)
     {
-        last_instruction_.emplace_back(InstRef::invalid());
+        last_instruction_.emplace(last_instruction_.begin() + num_qubits(), 
+                                  InstRef::invalid());
         return do_create_qubit(name);
     }
 
@@ -242,13 +243,14 @@ private:
 
     void connect_instruction(Instruction& inst)
     {
+        uint32_t const inst_uid = instructions_.size() - 1;
         for (auto& [wref, iref] : inst.qubits_) {
             iref = last_instruction_.at(wref);
-            last_instruction_.at(wref).uid_ = instructions_.size() - 1;
+            last_instruction_.at(wref).uid_ = inst_uid;
         }
         for (auto& [wref, iref] : inst.cbits_) {
             iref = last_instruction_.at(wref);
-            last_instruction_.at(wref).uid_ = instructions_.size() - 1;
+            last_instruction_.at(wref + num_qubits()).uid_ = inst_uid;
         }
     }
 

--- a/include/tweedledum/IR/Instruction.h
+++ b/include/tweedledum/IR/Instruction.h
@@ -188,15 +188,6 @@ public:
     }
 
     template<typename Fn>
-    void foreach_cbit(Fn&& fn) const
-    {
-        static_assert(std::is_invocable_r_v<void, Fn, WireRef>);
-        for (uint32_t i = 0; i < cbits_.size(); ++i) {
-            fn(cbits_[i].wire_ref);
-        }
-    }
-
-    template<typename Fn>
     void foreach_control(Fn&& fn) const
     {
         static_assert(std::is_invocable_r_v<void, Fn, Qubit>);

--- a/include/tweedledum/IR/Instruction.h
+++ b/include/tweedledum/IR/Instruction.h
@@ -57,15 +57,16 @@ public:
         , cbits_conns_(other.cbits_conns_)
     {}
 
-    Instruction(Instruction const& other, std::vector<Qubit> const& qubits)
+    Instruction(Instruction const& other, std::vector<Qubit> const& qubits,
+        std::vector<Cbit> const& cbits)
         : Operator(static_cast<Operator const&>(other))
     {
         for (Qubit qubit : qubits) {
             qubits_conns_.emplace_back(qubit, InstRef::invalid());
         }
-        // for (Cbit cbit : cbits) {
-        //     cbits_conns_.emplace_back(cbit, InstRef::invalid());
-        // }
+        for (Cbit cbit : cbits) {
+            cbits_conns_.emplace_back(cbit, InstRef::invalid());
+        }
         assert(qubits_conns_.size() >= this->num_targets());
     }
 
@@ -245,15 +246,16 @@ private:
     friend class Circuit;
 
     template<typename OpT>
-    Instruction(OpT&& optor, std::vector<Qubit> const& qubits)
+    Instruction(OpT&& optor, std::vector<Qubit> const& qubits,
+        std::vector<Cbit> const& cbits)
         : Operator(std::forward<OpT>(optor))
     {
         for (Qubit qubit : qubits) {
             qubits_conns_.emplace_back(qubit, InstRef::invalid());
         }
-        // for (Cbit cbit : cbits) {
-        //     cbits_conns_.emplace_back(cbit, InstRef::invalid());
-        // }
+        for (Cbit cbit : cbits) {
+            cbits_conns_.emplace_back(cbit, InstRef::invalid());
+        }
         assert(qubits_conns_.size() >= this->num_targets());
     }
 

--- a/include/tweedledum/IR/Instruction.h
+++ b/include/tweedledum/IR/Instruction.h
@@ -53,87 +53,96 @@ class Instruction : public Operator {
 public:
     // This is called by realloc!!
     Instruction(Instruction const& other)
-        : Operator(static_cast<Operator const&>(other)), qubits_(other.qubits_)
-        , cbits_(other.cbits_)
+        : Operator(static_cast<Operator const&>(other)), qubits_conns_(other.qubits_conns_)
+        , cbits_conns_(other.cbits_conns_)
     {}
 
-    Instruction(Instruction const& other, std::vector<WireRef> const& wires)
+    Instruction(Instruction const& other, std::vector<Qubit> const& qubits)
         : Operator(static_cast<Operator const&>(other))
     {
-        for (WireRef ref : wires) {
-            if (ref.kind() == Wire::Kind::quantum) {
-                qubits_.emplace_back(ref, InstRef::invalid());
-            } else {
-                cbits_.emplace_back(ref, InstRef::invalid());
-            }
+        for (Qubit qubit : qubits) {
+            qubits_conns_.emplace_back(qubit, InstRef::invalid());
         }
-        assert(qubits_.size() >= this->num_targets());
+        // for (Cbit cbit : cbits) {
+        //     cbits_conns_.emplace_back(cbit, InstRef::invalid());
+        // }
+        assert(qubits_conns_.size() >= this->num_targets());
     }
 
     uint32_t num_controls() const
     {
-        return qubits_.size() - this->num_targets();
+        return qubits_conns_.size() - this->num_targets();
     }
 
-    WireRef control(uint32_t const idx = 0u) const 
+    Qubit control(uint32_t const idx = 0u) const 
     {
         assert(idx < num_controls());
-        return qubits_[idx].wire_ref;
+        return qubits_conns_[idx].qubit;
     }
 
-    WireRef target(uint32_t const idx = 0u) const 
+    Qubit target(uint32_t const idx = 0u) const 
     {
         assert(idx < this->num_targets());
-        return qubits_[num_controls() + idx].wire_ref;
+        return qubits_conns_[num_controls() + idx].qubit;
     }
 
     uint32_t num_qubits() const
     {
-        return qubits_.size();
+        return qubits_conns_.size();
     }
 
     uint32_t num_cbits() const
     {
-        return cbits_.size();
+        return cbits_conns_.size();
     }
 
     uint32_t num_wires() const
     {
         return num_qubits() + num_cbits();
     }
- 
-    WireRef qubit(uint32_t idx) const
+
+    Qubit cbit(uint32_t idx) const
     {
-        assert(idx < qubits_.size());
-        return qubits_[idx].wire_ref;
+        assert(idx < qubits_conns_.size());
+        return qubits_conns_[idx].qubit;
     }
 
-    std::vector<WireRef> qubits() const
+    std::vector<Cbit> cbits() const
     {
-        std::vector<WireRef> qubits;
-        qubits.reserve(qubits_.size());
-        std::transform(qubits_.begin(), qubits_.end(), std::back_inserter(qubits),
-        [](Connection const& c) -> WireRef { return c.wire_ref; });
+        std::vector<Cbit> cbits;
+        cbits.reserve(cbits_conns_.size());
+        std::transform(cbits_conns_.begin(), cbits_conns_.end(), 
+        std::back_inserter(cbits), 
+        [](CbitConnection const& c) -> Cbit { 
+            return c.cbit; 
+        });
+        return cbits;
+    }
+
+    Qubit qubit(uint32_t idx) const
+    {
+        assert(idx < qubits_conns_.size());
+        return qubits_conns_[idx].qubit;
+    }
+
+    std::vector<Qubit> qubits() const
+    {
+        std::vector<Qubit> qubits;
+        qubits.reserve(qubits_conns_.size());
+        std::transform(qubits_conns_.begin(), qubits_conns_.end(), 
+        std::back_inserter(qubits), 
+        [](QubitConnection const& c) -> Qubit { 
+            return c.qubit; 
+        });
         return qubits;
-    }
-
-    std::vector<WireRef> wires() const
-    {
-        std::vector<WireRef> wires;
-        wires.reserve(qubits_.size()+ cbits_.size());
-        std::transform(qubits_.begin(), qubits_.end(), std::back_inserter(wires),
-        [](Connection const& c) -> WireRef { return c.wire_ref; });
-        std::transform(cbits_.begin(), cbits_.end(), std::back_inserter(wires),
-        [](Connection const& c) -> WireRef { return c.wire_ref; });
-        return wires;
     }
 
     bool is_adjoint(Instruction const& other) const
     {
-        if (qubits_ != other.qubits_) {
+        if (qubits_conns_ != other.qubits_conns_) {
             return false;
         }
-        if (cbits_ != other.cbits_) {
+        if (cbits_conns_ != other.cbits_conns_) {
             return false;
         }
         std::optional<Operator> adj = other.adjoint();
@@ -143,21 +152,14 @@ public:
         return static_cast<Operator const&>(*this) == *adj;
     }
 
-    // bool is_dependent(Instruction const& other) const
-    // {
-    //     // Need to check the Operators
-    //     return true;
-    // }
-    
     template<typename Fn>
-    void foreach_wire(Fn&& fn) const
+    void foreach_cbit(Fn&& fn) const
     {
-        static_assert(std::is_invocable_r_v<void, Fn, WireRef> ||
+        static_assert(std::is_invocable_r_v<void, Fn, Cbit> ||
                       std::is_invocable_r_v<void, Fn, InstRef>);
-
-        for (Connection const& connection : qubits_) {
-            if constexpr (std::is_invocable_r_v<void, Fn, WireRef>) {
-                fn(connection.wire_ref);
+        for (CbitConnection const& connection : cbits_conns_) {
+            if constexpr (std::is_invocable_r_v<void, Fn, Cbit>) {
+                fn(connection.cbit);
             } else {
                 if (connection.inst_ref == InstRef::invalid()) {
                     continue;
@@ -165,9 +167,16 @@ public:
                 fn(connection.inst_ref);
             }
         }
-        for (Connection const& connection : cbits_) {
-            if constexpr (std::is_invocable_r_v<void, Fn, WireRef>) {
-                fn(connection.wire_ref);
+    }
+
+    template<typename Fn>
+    void foreach_qubit(Fn&& fn) const
+    {
+        static_assert(std::is_invocable_r_v<void, Fn, Qubit> ||
+                      std::is_invocable_r_v<void, Fn, InstRef>);
+        for (QubitConnection const& connection : qubits_conns_) {
+            if constexpr (std::is_invocable_r_v<void, Fn, Qubit>) {
+                fn(connection.qubit);
             } else {
                 if (connection.inst_ref == InstRef::invalid()) {
                     continue;
@@ -180,76 +189,77 @@ public:
     template<typename Fn>
     void foreach_control(Fn&& fn) const
     {
-        static_assert(std::is_invocable_r_v<void, Fn, WireRef>);
-        for (uint32_t i = 0; i < qubits_.size() - num_targets(); ++i) {
-            fn(qubits_[i].wire_ref);
+        static_assert(std::is_invocable_r_v<void, Fn, Qubit>);
+        for (uint32_t i = 0; i < qubits_conns_.size() - num_targets(); ++i) {
+            fn(qubits_conns_[i].qubit);
         }
     }
 
     template<typename Fn>
     void foreach_target(Fn&& fn) const
     {
-        static_assert(std::is_invocable_r_v<void, Fn, WireRef>);
-        for (uint32_t i = num_controls(); i < qubits_.size(); ++i) {
-            fn(qubits_[i].wire_ref);
+        static_assert(std::is_invocable_r_v<void, Fn, Qubit>);
+        for (uint32_t i = num_controls(); i < qubits_conns_.size(); ++i) {
+            fn(qubits_conns_[i].qubit);
         }
-    }
-
-    // FIXME: I want to make these at least protected..
-    auto py_begin() const
-    {
-        return qubits_.begin();
-    }
-
-    auto py_end() const
-    {
-        return qubits_.end();
     }
 
     bool operator==(Instruction const& other) const
     {
-        if (qubits_ != other.qubits_) {
+        if (qubits_conns_ != other.qubits_conns_) {
             return false;
         }
-        if (cbits_ != other.cbits_) {
+        if (cbits_conns_ != other.cbits_conns_) {
             return false;
         }
         return static_cast<Operator const&>(*this) == static_cast<Operator const&>(other);
     }
 
 private:
-    struct Connection {
-        WireRef wire_ref;
+    struct QubitConnection {
+        Qubit qubit;
         InstRef inst_ref;
-        Connection(WireRef w, InstRef i) : wire_ref(w), inst_ref(i)
+        QubitConnection(Qubit qubit, InstRef i) : qubit(qubit), inst_ref(i)
         {}
 
         // FIXME: this quite counterintuitive
-        bool operator==(Connection const& other) const
+        bool operator==(QubitConnection const& other) const
         {
-            return wire_ref == other.wire_ref;
+            return qubit == other.qubit;
+        }
+    };
+
+    struct CbitConnection {
+        Cbit cbit;
+        InstRef inst_ref;
+        CbitConnection(Cbit cbit, InstRef i) : cbit(cbit), inst_ref(i)
+        {}
+
+        // FIXME: this quite counterintuitive
+        bool operator==(CbitConnection const& other) const
+        {
+            return cbit == other.cbit;
         }
     };
 
     friend class Circuit;
 
     template<typename OpT>
-    Instruction(OpT&& optor, std::vector<WireRef> const& wires)
+    Instruction(OpT&& optor, std::vector<Qubit> const& qubits)
         : Operator(std::forward<OpT>(optor))
     {
-        for (WireRef ref : wires) {
-            if (ref.kind() == Wire::Kind::quantum) {
-                qubits_.emplace_back(ref, InstRef::invalid());
-            } else {
-                cbits_.emplace_back(ref, InstRef::invalid());
-            }
+        for (Qubit qubit : qubits) {
+            qubits_conns_.emplace_back(qubit, InstRef::invalid());
         }
-        assert(qubits_.size() >= this->num_targets());
+        // for (Cbit cbit : cbits) {
+        //     cbits_conns_.emplace_back(cbit, InstRef::invalid());
+        // }
+        assert(qubits_conns_.size() >= this->num_targets());
     }
 
     // TODO: Come up with a good value for the size of the inline buffer!
-    SmallVector<Connection, 3> qubits_;
-    SmallVector<Connection, 1> cbits_;
+    SmallVector<QubitConnection, 3> qubits_conns_;
+    SmallVector<CbitConnection, 1> cbits_conns_;
 
     // I not sure about this:
     // This is needed because the constructor is private and a container such

--- a/include/tweedledum/IR/Qubit.h
+++ b/include/tweedledum/IR/Qubit.h
@@ -1,0 +1,90 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#pragma once
+
+#include <cassert>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace tweedledum {
+
+class WireStorage;
+
+class Qubit {
+public:
+    enum Polarity : uint32_t {
+        positive = 0u, 
+        negative = 1u 
+    };
+
+    // Return the sentinel value
+    static constexpr Qubit invalid()
+    {
+        return Qubit();
+    }
+
+    Qubit(Qubit const& other) = default;
+
+    Qubit& operator=(Qubit const& other)
+    {
+        data_ = other.data_;
+        return *this;
+    }
+
+    uint32_t uid() const
+    {
+        return uid_;
+    }
+
+    Polarity polarity() const
+    {
+        return static_cast<Polarity>(polarity_);
+    }
+
+    Qubit operator!() const
+    {
+        Qubit complemented(*this);
+        complemented.polarity_ ^= 1u;
+        return complemented;
+    }
+
+    bool operator==(Qubit other) const
+    {
+        return data_ == other.data_;
+    }
+
+    bool operator!=(Qubit other) const
+    {
+        return data_ != other.data_;
+    }
+
+    operator uint32_t() const
+    {
+        return uid_;
+    }
+
+protected:
+    friend class WireStorage;
+
+    constexpr Qubit(uint32_t uid, Polarity polarity = Polarity::positive)
+        : uid_(uid), polarity_(static_cast<uint32_t>(polarity))
+    {}
+
+    union {
+        uint32_t data_;
+        struct {
+            uint32_t const uid_ : 31;
+            uint32_t polarity_ : 1;
+        };
+    };
+
+private:
+    constexpr Qubit()
+        : data_(std::numeric_limits<uint32_t>::max())
+    {}
+};
+
+} // namespace tweedledum

--- a/include/tweedledum/Operators/Extension/Unitary.h
+++ b/include/tweedledum/Operators/Extension/Unitary.h
@@ -110,7 +110,7 @@ public:
     {}
 
     template<typename OpT>
-    void apply_operator(OpT&& optor, std::vector<WireRef> const& qubits)
+    void apply_operator(OpT&& optor, std::vector<Qubit> const& qubits)
     {
         std::vector<uint32_t> const temp_qubits(qubits.begin(), qubits.end());
         apply_operator(std::forward<OpT>(optor), temp_qubits);

--- a/include/tweedledum/Operators/Utils.h
+++ b/include/tweedledum/Operators/Utils.h
@@ -13,7 +13,7 @@
 
 namespace tweedledum {
 
-inline void apply_identified_phase(Circuit& circuit, Angle angle, WireRef target)
+inline void apply_identified_phase(Circuit& circuit, Angle angle, Qubit target)
 {
     if (!angle.is_numerically_defined()) {
         if (angle == sym_angle::pi_quarter) {

--- a/include/tweedledum/Passes/Decomposition/barenco_decomp.h
+++ b/include/tweedledum/Passes/Decomposition/barenco_decomp.h
@@ -13,10 +13,13 @@
 
 namespace tweedledum {
 
-void barenco_decomp(Circuit& circuit, Instruction const& inst, nlohmann::json const& config = {});
+void barenco_decomp(Circuit& circuit, Instruction const& inst,
+    nlohmann::json const& config = {});
 
-void barenco_decomp(Circuit& circuit, Circuit const& original, nlohmann::json const& config = {});
+void barenco_decomp(Circuit& circuit, Circuit const& original,
+    nlohmann::json const& config = {});
 
-Circuit barenco_decomp(Circuit const& original, nlohmann::json const& config = {});
+Circuit barenco_decomp(Circuit const& original, 
+    nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Decomposition/euler_decomp.h
+++ b/include/tweedledum/Passes/Decomposition/euler_decomp.h
@@ -13,8 +13,10 @@
 
 namespace tweedledum {
 
-void euler_decomp(Circuit& circuit, Instruction const& inst, nlohmann::json const& config = {});
+void euler_decomp(Circuit& circuit, Instruction const& inst,
+    nlohmann::json const& config = {});
 
-Circuit euler_decomp(Circuit const& original, nlohmann::json const& config = {});
+Circuit euler_decomp(Circuit const& original,
+    nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Mapping/MapState.h
+++ b/include/tweedledum/Passes/Mapping/MapState.h
@@ -7,6 +7,7 @@
 #include "../../IR/Circuit.h"
 #include "../../IR/Wire.h"
 #include "../../Target/Device.h"
+#include "../Utility/shallow_duplicate.h"
 
 #include <vector>
 
@@ -15,33 +16,13 @@ namespace tweedledum {
 struct MapState {
 
     MapState(Circuit const& original, Device const& device)
-    : device(device), original(original)
-    , wire_to_v(original.num_wires(), WireRef::invalid())
+    : device(device), original(original), mapped(shallow_duplicate(original))
     , v_to_phy(device.num_qubits(), WireRef::invalid())
     , phy_to_v(device.num_qubits(), WireRef::invalid())
     {
-        original.foreach_wire([&](Wire const& wire) {
-            if (wire.kind == Wire::Kind::quantum) {
-                WireRef const new_wire = mapped.create_qubit(wire.name);
-                wire_to_v.at(wire) = new_wire;
-            }
-        });
         for (uint32_t i = original.num_qubits(); i < device.num_qubits(); ++i) {
             mapped.create_qubit();
         }
-        original.foreach_wire([&](Wire const& wire) {
-            if (wire.kind == Wire::Kind::classical) {
-                wire_to_v.at(wire) = mapped.create_cbit(wire.name);
-            }
-        });
-    }
-
-    WireRef wire_to_wire(WireRef const ref) const
-    {
-        if (ref.kind() == Wire::Kind::quantum) {
-            return v_to_phy.at(wire_to_v.at(ref));
-        }
-        return wire_to_v.at(ref);
     }
 
     void swap_qubits(WireRef const phy0, WireRef const phy1)
@@ -61,7 +42,6 @@ struct MapState {
     Device const& device;
     Circuit const& original;
     Circuit mapped;
-    std::vector<WireRef> wire_to_v;
     std::vector<WireRef> v_to_phy;
     std::vector<WireRef> phy_to_v;
 };

--- a/include/tweedledum/Passes/Mapping/MapState.h
+++ b/include/tweedledum/Passes/Mapping/MapState.h
@@ -17,23 +17,23 @@ struct MapState {
 
     MapState(Circuit const& original, Device const& device)
     : device(device), original(original), mapped(shallow_duplicate(original))
-    , v_to_phy(device.num_qubits(), WireRef::invalid())
-    , phy_to_v(device.num_qubits(), WireRef::invalid())
+    , v_to_phy(device.num_qubits(), Qubit::invalid())
+    , phy_to_v(device.num_qubits(), Qubit::invalid())
     {
         for (uint32_t i = original.num_qubits(); i < device.num_qubits(); ++i) {
             mapped.create_qubit();
         }
     }
 
-    void swap_qubits(WireRef const phy0, WireRef const phy1)
+    void swap_qubits(Qubit const phy0, Qubit const phy1)
     {
         assert(device.are_connected(phy0, phy1));
-        WireRef const v0 = phy_to_v.at(phy0);
-        WireRef const v1 = phy_to_v.at(phy1);
-        if (v0 != WireRef::invalid()) {
+        Qubit const v0 = phy_to_v.at(phy0);
+        Qubit const v1 = phy_to_v.at(phy1);
+        if (v0 != Qubit::invalid()) {
             v_to_phy.at(v0) = phy1;
         }
-        if (v1 != WireRef::invalid()) {
+        if (v1 != Qubit::invalid()) {
             v_to_phy.at(v1) = phy0;
         }
         std::swap(phy_to_v.at(phy0), phy_to_v.at(phy1));
@@ -42,8 +42,8 @@ struct MapState {
     Device const& device;
     Circuit const& original;
     Circuit mapped;
-    std::vector<WireRef> v_to_phy;
-    std::vector<WireRef> phy_to_v;
+    std::vector<Qubit> v_to_phy;
+    std::vector<Qubit> phy_to_v;
 };
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Mapping/Placer/JITPlacer.h
+++ b/include/tweedledum/Passes/Mapping/Placer/JITPlacer.h
@@ -35,7 +35,7 @@ public:
     }
 
 private:
-    using Swap = std::pair<WireRef, WireRef>;
+    using Swap = std::pair<Qubit, Qubit>;
 
     void do_run();
 
@@ -50,19 +50,19 @@ private:
 
     void select_extended_layer();
 
-    std::vector<WireRef> find_free_phy() const;
+    std::vector<Qubit> find_free_phy() const;
 
-    void place_two_v(WireRef const v0, WireRef const v1);
+    void place_two_v(Qubit const v0, Qubit const v1);
 
-    void place_one_v(WireRef const v0, WireRef const v1);
+    void place_one_v(Qubit const v0, Qubit const v1);
 
     bool add_instruction(Instruction const& inst);
 
-    void add_swap(WireRef const phy0, WireRef const phy1);
+    void add_swap(Qubit const phy0, Qubit const phy1);
 
     Swap find_swap();
 
-    double compute_cost(std::vector<WireRef> const&, std::vector<InstRef> const&);
+    double compute_cost(std::vector<Qubit> const&, std::vector<InstRef> const&);
 
     MapState& state_;
     Circuit const* current_;

--- a/include/tweedledum/Passes/Mapping/Placer/LinePlacer.h
+++ b/include/tweedledum/Passes/Mapping/Placer/LinePlacer.h
@@ -22,8 +22,8 @@ public:
 
     void run()
     {
-        std::fill(state_.v_to_phy.begin(), state_.v_to_phy.end(), WireRef::invalid());
-        std::fill(state_.phy_to_v.begin(), state_.phy_to_v.end(), WireRef::invalid());
+        std::fill(state_.v_to_phy.begin(), state_.v_to_phy.end(), Qubit::invalid());
+        std::fill(state_.phy_to_v.begin(), state_.phy_to_v.end(), Qubit::invalid());
         partition_into_timeframes();
         build_connectivity_graph();
         extract_lines();

--- a/include/tweedledum/Passes/Mapping/Placer/RandomPlacer.h
+++ b/include/tweedledum/Passes/Mapping/Placer/RandomPlacer.h
@@ -22,13 +22,11 @@ public:
     bool run(uint32_t seed = 17u)
     {
         // Initialize with the trivial placement
-        for (uint32_t i = 0u; i < state_.mapped.num_qubits(); ++i) {
-            state_.v_to_phy.at(i) = state_.mapped.wire_ref(i);
-        }
+        state_.v_to_phy = state_.mapped.qubits();
         std::mt19937 rnd(seed);
         std::shuffle(state_.v_to_phy.begin(), state_.v_to_phy.end(), rnd);
         for (uint32_t i = 0u; i < state_.v_to_phy.size(); ++i) {
-            state_.phy_to_v.at(state_.v_to_phy.at(i)) = state_.mapped.wire_ref(i);
+            state_.phy_to_v.at(state_.v_to_phy.at(i)) = state_.mapped.qubit(i);
         }
         return false;
     }

--- a/include/tweedledum/Passes/Mapping/Placer/SabrePlacer.h
+++ b/include/tweedledum/Passes/Mapping/Placer/SabrePlacer.h
@@ -34,7 +34,7 @@ public:
     }
 
 private:
-    using Swap = std::pair<WireRef, WireRef>;
+    using Swap = std::pair<Qubit, Qubit>;
 
     void do_run();
 
@@ -50,11 +50,11 @@ private:
 
     bool add_instruction(Instruction const& inst);
 
-    void add_swap(WireRef const phy0, WireRef const phy1);
+    void add_swap(Qubit const phy0, Qubit const phy1);
 
     Swap find_swap();
 
-    double compute_cost(std::vector<WireRef> const&, std::vector<InstRef> const&);
+    double compute_cost(std::vector<Qubit> const&, std::vector<InstRef> const&);
 
     MapState& state_;
     Circuit const* current_;

--- a/include/tweedledum/Passes/Mapping/Router/JITRouter.h
+++ b/include/tweedledum/Passes/Mapping/Router/JITRouter.h
@@ -32,7 +32,7 @@ public:
     }
 
 private:
-    using Swap = std::pair<WireRef, WireRef>;
+    using Swap = std::pair<Qubit, Qubit>;
 
     void do_run();
 
@@ -40,23 +40,23 @@ private:
 
     void select_extended_layer();
 
-    std::vector<WireRef> find_free_phy() const;
+    std::vector<Qubit> find_free_phy() const;
 
-    void place_two_v(WireRef const v0, WireRef const v1);
+    void place_two_v(Qubit const v0, Qubit const v1);
 
-    void place_one_v(WireRef const v0, WireRef const v1);
+    void place_one_v(Qubit const v0, Qubit const v1);
 
     void add_instruction(Instruction const& inst);
 
-    void add_delayed(WireRef const v);
+    void add_delayed(Qubit const v);
 
-    void add_swap(WireRef const phy0, WireRef const phy1);
+    void add_swap(Qubit const phy0, Qubit const phy1);
 
     bool try_add_instruction(InstRef ref, Instruction const& inst);
 
     Swap find_swap();
 
-    double compute_cost(std::vector<WireRef> const&, std::vector<InstRef> const&);
+    double compute_cost(std::vector<Qubit> const&, std::vector<InstRef> const&);
 
     MapState& state_;
     Circuit* mapped_;

--- a/include/tweedledum/Passes/Mapping/Router/SabreRouter.h
+++ b/include/tweedledum/Passes/Mapping/Router/SabreRouter.h
@@ -22,7 +22,7 @@ public:
     void run();
 
 private:
-    using Swap = std::pair<WireRef, WireRef>;
+    using Swap = std::pair<Qubit, Qubit>;
 
     bool add_front_layer();
 
@@ -30,11 +30,11 @@ private:
 
     bool add_instruction(Instruction const& inst);
 
-    void add_swap(WireRef const phy0, WireRef const phy1);
+    void add_swap(Qubit const phy0, Qubit const phy1);
 
     Swap find_swap();
 
-    double compute_cost(std::vector<WireRef> const&, std::vector<InstRef> const&);
+    double compute_cost(std::vector<Qubit> const&, std::vector<InstRef> const&);
 
     MapState& state_;
     std::vector<uint32_t> visited_;

--- a/include/tweedledum/Passes/Simulation/simulate_classically.h
+++ b/include/tweedledum/Passes/Simulation/simulate_classically.h
@@ -17,10 +17,10 @@ inline DynamicBitset<WordType> simulate_classically(
 {
     assert(circuit.num_qubits() == pattern.size());
     circuit.foreach_instruction([&](Instruction const& inst) {
-        WireRef target = WireRef::invalid();
+        Qubit target = Qubit::invalid();
         bool execute = true;
         if (inst.is_a<Op::X>()) {
-            inst.foreach_control([&](WireRef const& wire) {
+            inst.foreach_control([&](Qubit const& wire) {
                 auto bit = pattern[wire];
                 execute &= bit ^ wire.polarity();
             });
@@ -32,7 +32,7 @@ inline DynamicBitset<WordType> simulate_classically(
             }
             uint32_t pos = 0u;
             for (uint32_t i = 0; i < inst.num_qubits() - 1; ++i) {
-                WireRef const wire = inst.target(i);
+                Qubit const wire = inst.target(i);
                 pos |= (pattern[wire] << i);
             }
             execute &= kitty::get_bit(tt.truth_table(), pos);

--- a/include/tweedledum/Passes/Synthesis/all_linear_synth.h
+++ b/include/tweedledum/Passes/Synthesis/all_linear_synth.h
@@ -60,9 +60,11 @@ namespace tweedledum {
  * 
  * \param[inout] circuit A circuit in which the parities will be synthesized on.
  * \param[in] qubits The qubits that will be used.
+ * \param[in] cbits The cbits that will be used.
  * \param[in] parities List of parities and their associated angles.
  */
-void all_linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits, LinearPP const& parities);
+void all_linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
+    std::vector<Cbit> const& cbits, LinearPP const& parities);
 
 /*! \brief Synthesis of a CNOT-dihedral circuits with all linear combinations.
  *

--- a/include/tweedledum/Passes/Synthesis/all_linear_synth.h
+++ b/include/tweedledum/Passes/Synthesis/all_linear_synth.h
@@ -62,7 +62,7 @@ namespace tweedledum {
  * \param[in] qubits The qubits that will be used.
  * \param[in] parities List of parities and their associated angles.
  */
-void all_linear_synth(Circuit& circuit, std::vector<WireRef> const& qubits, LinearPP const& parities);
+void all_linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits, LinearPP const& parities);
 
 /*! \brief Synthesis of a CNOT-dihedral circuits with all linear combinations.
  *

--- a/include/tweedledum/Passes/Synthesis/decomp_synth.h
+++ b/include/tweedledum/Passes/Synthesis/decomp_synth.h
@@ -23,7 +23,7 @@ namespace tweedledum {
  * \param[in] qubits The wires that will be used.
  * \param[in] perm A vector of different integers.
  */
-void decomp_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void decomp_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     std::vector<uint32_t> const& perm);
 
 /*! \brief Reversible synthesis based on functional decomposition.

--- a/include/tweedledum/Passes/Synthesis/decomp_synth.h
+++ b/include/tweedledum/Passes/Synthesis/decomp_synth.h
@@ -21,10 +21,11 @@ namespace tweedledum {
  * \param[inout] circuit A circuit in which the permutation will be synthesized
  * on.
  * \param[in] qubits The wires that will be used.
+ * \param[in] cbits The cbits that will be used.
  * \param[in] perm A vector of different integers.
  */
 void decomp_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    std::vector<uint32_t> const& perm);
+    std::vector<Cbit> const& cbits, std::vector<uint32_t> const& perm);
 
 /*! \brief Reversible synthesis based on functional decomposition.
  *

--- a/include/tweedledum/Passes/Synthesis/diagonal_synth.h
+++ b/include/tweedledum/Passes/Synthesis/diagonal_synth.h
@@ -14,8 +14,10 @@
 namespace tweedledum {
 
 void diagonal_synth(Circuit& circuit, std::vector<Qubit> qubits,
-    std::vector<Angle> const& angles, nlohmann::json const& config);
+    std::vector<Cbit> const& cbits, std::vector<Angle> const& angles,
+    nlohmann::json const& config = {});
 
-Circuit diagonal_synth(std::vector<Angle> const& angles, nlohmann::json const& config);
+Circuit diagonal_synth(std::vector<Angle> const& angles,
+    nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Synthesis/diagonal_synth.h
+++ b/include/tweedledum/Passes/Synthesis/diagonal_synth.h
@@ -13,7 +13,7 @@
 
 namespace tweedledum {
 
-void diagonal_synth(Circuit& circuit, std::vector<WireRef> qubits,
+void diagonal_synth(Circuit& circuit, std::vector<Qubit> qubits,
     std::vector<Angle> const& angles, nlohmann::json const& config);
 
 Circuit diagonal_synth(std::vector<Angle> const& angles, nlohmann::json const& config);

--- a/include/tweedledum/Passes/Synthesis/gray_synth.h
+++ b/include/tweedledum/Passes/Synthesis/gray_synth.h
@@ -45,7 +45,7 @@ namespace tweedledum {
  * \param[in] parities List of parities and their associated angles.
  */
 // Each column is a parity, num_rows = num_qubits
-void gray_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     BMatrix linear_trans, LinearPP parities,
     nlohmann::json const& config);
 

--- a/include/tweedledum/Passes/Synthesis/gray_synth.h
+++ b/include/tweedledum/Passes/Synthesis/gray_synth.h
@@ -41,13 +41,14 @@ namespace tweedledum {
  *
  * \param[inout] circuit A circuit in which the parities will be synthesized on.
  * \param[in] qubits The qubits that will be used.
+ * \param[in] cbits The cbits that will be used.
  * \param[in] linear_trans The overall linear transformation
  * \param[in] parities List of parities and their associated angles.
  */
 // Each column is a parity, num_rows = num_qubits
-void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    BMatrix linear_trans, LinearPP parities,
-    nlohmann::json const& config);
+void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits, 
+    std::vector<Cbit> const& cbits, BMatrix linear_trans, LinearPP parities,
+    nlohmann::json const& config = {});
 
 /*! \brief Synthesis of a CNOT-dihedral circuits.
  *
@@ -56,6 +57,6 @@ void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
  * \return A CNOT-dihedral circuit on `num_qubits`.
  */
 Circuit gray_synth(uint32_t num_qubits, LinearPP const& parities,
-    nlohmann::json const& config);
+    nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Synthesis/lhrs_synth.h
+++ b/include/tweedledum/Passes/Synthesis/lhrs_synth.h
@@ -13,7 +13,7 @@
 
 namespace tweedledum {
 
-void lhrs_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void lhrs_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     mockturtle::xag_network const& xag, nlohmann::json const& config);
 
 //  LUT-based hierarchical reversible logic synthesis (LHRS)

--- a/include/tweedledum/Passes/Synthesis/lhrs_synth.h
+++ b/include/tweedledum/Passes/Synthesis/lhrs_synth.h
@@ -14,9 +14,11 @@
 namespace tweedledum {
 
 void lhrs_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    mockturtle::xag_network const& xag, nlohmann::json const& config);
+    std::vector<Cbit> const& cbits, mockturtle::xag_network const& xag,
+    nlohmann::json const& config = {});
 
 //  LUT-based hierarchical reversible logic synthesis (LHRS)
-Circuit lhrs_synth(mockturtle::xag_network const& xag, nlohmann::json const& config);
+Circuit lhrs_synth(mockturtle::xag_network const& xag,
+    nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Synthesis/linear_synth.h
+++ b/include/tweedledum/Passes/Synthesis/linear_synth.h
@@ -51,7 +51,7 @@ namespace tweedledum {
  * \param[in] qubits The wires that will be used.
  * \param[in] matrix An N x N binary matrix.
  */
-void linear_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     BMatrix const& matrix, nlohmann::json const& config);
 
 /*! \brief Synthesis of linear reversible circuits (CNOT synthesis).

--- a/include/tweedledum/Passes/Synthesis/linear_synth.h
+++ b/include/tweedledum/Passes/Synthesis/linear_synth.h
@@ -28,7 +28,7 @@
 //
 // What is the problem we are trying to solve here?
 //
-//    Synthesize an arbitrary linear reversible circuit on N wires using as
+//    Synthesize an arbitrary linear reversible circuit on N qubits using as
 //    few CX gates as possible.
 //
 // This problem can be mapped to the problem of row reducing an N × N binary 
@@ -48,17 +48,19 @@ namespace tweedledum {
  * 
  * \param[inout] circuit A circuit in which the linear transformation will be 
  * synthesized on.
- * \param[in] qubits The wires that will be used.
+ * \param[in] qubits The qubits that will be used.
+ * \param[in] cbits The cbits that will be used.
  * \param[in] matrix An N x N binary matrix.
  */
 void linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    BMatrix const& matrix, nlohmann::json const& config);
+    std::vector<Cbit> const& cbits, BMatrix const& matrix,
+    nlohmann::json const& config = {});
 
 /*! \brief Synthesis of linear reversible circuits (CNOT synthesis).
  *
  * \param[in] matrix An N x N binary matrix.
- * \return A linear reversible circuit on N wires.
+ * \return A linear reversible circuit on N qubits.
  */
-Circuit linear_synth(BMatrix const& matrix, nlohmann::json const& config);
+Circuit linear_synth(BMatrix const& matrix, nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Synthesis/pkrm_synth.h
+++ b/include/tweedledum/Passes/Synthesis/pkrm_synth.h
@@ -17,16 +17,10 @@ namespace tweedledum {
 // Synthesize a quantum circuit from a function by computing PKRM representation
 // PKRM: Pseudo-Kronecker Read-Muller expression---a special case of an ESOP form.
 void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
+     std::vector<Cbit> const& cbits, kitty::dynamic_truth_table const& function,
+     nlohmann::json const& config = {});
 
-Circuit pkrm_synth(kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
-
-void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    Instruction const& inst, nlohmann::json const& config = {});
-
-void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    mockturtle::xag_network const& xag, nlohmann::json const& config);
-
-Circuit pkrm_synth(mockturtle::xag_network const& xag, nlohmann::json const& config);
+Circuit pkrm_synth(kitty::dynamic_truth_table const& function,
+    nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Synthesis/pkrm_synth.h
+++ b/include/tweedledum/Passes/Synthesis/pkrm_synth.h
@@ -16,15 +16,15 @@ namespace tweedledum {
 
 // Synthesize a quantum circuit from a function by computing PKRM representation
 // PKRM: Pseudo-Kronecker Read-Muller expression---a special case of an ESOP form.
-void pkrm_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
 
 Circuit pkrm_synth(kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
 
-void pkrm_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     Instruction const& inst, nlohmann::json const& config = {});
 
-void pkrm_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     mockturtle::xag_network const& xag, nlohmann::json const& config);
 
 Circuit pkrm_synth(mockturtle::xag_network const& xag, nlohmann::json const& config);

--- a/include/tweedledum/Passes/Synthesis/pprm_synth.h
+++ b/include/tweedledum/Passes/Synthesis/pprm_synth.h
@@ -17,7 +17,7 @@ namespace tweedledum {
 // PPRM: The positive polarity Reed-Muller form is an ESOP, where each variable has
 // positive polarity (not complemented form). PPRM is a canonical expression, so further
 // minimization is not possible.
-void pprm_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void pprm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
 
 Circuit pprm_synth(kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});

--- a/include/tweedledum/Passes/Synthesis/pprm_synth.h
+++ b/include/tweedledum/Passes/Synthesis/pprm_synth.h
@@ -18,8 +18,10 @@ namespace tweedledum {
 // positive polarity (not complemented form). PPRM is a canonical expression, so further
 // minimization is not possible.
 void pprm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
+    std::vector<Cbit> const& cbits, kitty::dynamic_truth_table const& function,
+    nlohmann::json const& config = {});
 
-Circuit pprm_synth(kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
+Circuit pprm_synth(kitty::dynamic_truth_table const& function,
+    nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Synthesis/spectrum_synth.h
+++ b/include/tweedledum/Passes/Synthesis/spectrum_synth.h
@@ -13,7 +13,7 @@
 
 namespace tweedledum {
 
-void spectrum_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void spectrum_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
 
 Circuit spectrum_synth(kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});

--- a/include/tweedledum/Passes/Synthesis/spectrum_synth.h
+++ b/include/tweedledum/Passes/Synthesis/spectrum_synth.h
@@ -14,8 +14,10 @@
 namespace tweedledum {
 
 void spectrum_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
+    std::vector<Cbit> const& cbits, kitty::dynamic_truth_table const& function,
+    nlohmann::json const& config = {});
 
-Circuit spectrum_synth(kitty::dynamic_truth_table const& function, nlohmann::json const& config = {});
+Circuit spectrum_synth(kitty::dynamic_truth_table const& function,
+    nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Synthesis/transform_synth.h
+++ b/include/tweedledum/Passes/Synthesis/transform_synth.h
@@ -46,7 +46,7 @@ namespace tweedledum {
  * \param[in] qubits The wires that will be used.
  * \param[in] perm A vector of different integers.
  */
-void transform_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void transform_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     std::vector<uint32_t> const& perm);
 
 /*! \brief Reversible synthesis based on symbolic transformation.

--- a/include/tweedledum/Passes/Synthesis/transform_synth.h
+++ b/include/tweedledum/Passes/Synthesis/transform_synth.h
@@ -43,11 +43,12 @@ namespace tweedledum {
  * 
  * \param[inout] circuit A circuit in which the permutation will be synthesized
  * on.
- * \param[in] qubits The wires that will be used.
+ * \param[in] qubits The qubits that will be used.
+ * \param[in] cbits The cbits that will be used.
  * \param[in] perm A vector of different integers.
  */
 void transform_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    std::vector<uint32_t> const& perm);
+    std::vector<Cbit> const& cbits, std::vector<uint32_t> const& perm);
 
 /*! \brief Reversible synthesis based on symbolic transformation.
  *

--- a/include/tweedledum/Passes/Synthesis/xag_synth.h
+++ b/include/tweedledum/Passes/Synthesis/xag_synth.h
@@ -13,7 +13,7 @@
 
 namespace tweedledum {
 
-void xag_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void xag_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     mockturtle::xag_network const& xag, nlohmann::json const& config = {});
 
 Circuit xag_synth(mockturtle::xag_network const& xag, nlohmann::json const& config = {});

--- a/include/tweedledum/Passes/Synthesis/xag_synth.h
+++ b/include/tweedledum/Passes/Synthesis/xag_synth.h
@@ -14,8 +14,10 @@
 namespace tweedledum {
 
 void xag_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    mockturtle::xag_network const& xag, nlohmann::json const& config = {});
+    std::vector<Cbit> const& cbits, mockturtle::xag_network const& xag,
+    nlohmann::json const& config = {});
 
-Circuit xag_synth(mockturtle::xag_network const& xag, nlohmann::json const& config = {});
+Circuit xag_synth(mockturtle::xag_network const& xag,
+   nlohmann::json const& config = {});
 
 } // namespace tweedledum

--- a/include/tweedledum/Passes/Utility/shallow_duplicate.h
+++ b/include/tweedledum/Passes/Utility/shallow_duplicate.h
@@ -20,16 +20,11 @@ namespace tweedledum {
 inline Circuit shallow_duplicate(Circuit const& original)
 {
     Circuit duplicate;
-    original.foreach_wire([&](Wire const& wire) {
-        switch (wire.kind) {
-        case Wire::Kind::classical:
-            duplicate.create_cbit(wire.name);
-            break;
-
-        case Wire::Kind::quantum:
-            duplicate.create_qubit(wire.name);
-            break;
-        }
+    original.foreach_cbit([&](std::string_view name) {
+        duplicate.create_cbit(name);
+    });
+    original.foreach_qubit([&](std::string_view name) {
+        duplicate.create_qubit(name);
     });
     return duplicate;
 }

--- a/include/tweedledum/Passes/Utility/shallow_duplicate.h
+++ b/include/tweedledum/Passes/Utility/shallow_duplicate.h
@@ -20,8 +20,7 @@ namespace tweedledum {
 inline Circuit shallow_duplicate(Circuit const& original)
 {
     Circuit duplicate;
-    std::for_each(original.begin_wire(), original.end_wire(),
-    [&](Wire const& wire) {
+    original.foreach_wire([&](Wire const& wire) {
         switch (wire.kind) {
         case Wire::Kind::classical:
             duplicate.create_cbit(wire.name);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,4 +2,4 @@
 # CMake build : tweedledum library
 add_subdirectory(Passes)
 add_subdirectory(Target)
-# add_subdirectory(Utils)
+add_subdirectory(Utils)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,4 +2,4 @@
 # CMake build : tweedledum library
 add_subdirectory(Passes)
 add_subdirectory(Target)
-add_subdirectory(Utils)
+# add_subdirectory(Utils)

--- a/lib/Passes/Decomposition/barenco_decomp.cpp
+++ b/lib/Passes/Decomposition/barenco_decomp.cpp
@@ -14,25 +14,28 @@ namespace {
 struct Config {
     uint32_t controls_threshold;
     uint32_t max_qubits;
-    // std::vector<uint8_t> locked;
     Qubit locked;
-    Operator const compute_op;
-    Operator const cleanup_op;
+    Operator compute_op;
+    Operator cleanup_op;
 
-    Config(uint32_t n, nlohmann::json const& config)
+    Config(nlohmann::json const& config)
         : controls_threshold(2u)
         , max_qubits(0u)
-        // , locked(n, 0)
         , locked(Qubit::invalid())
         , compute_op(Op::Rx(sym_angle::pi))
         , cleanup_op(Op::Rx(-sym_angle::pi))
-        // , compute_op(Op::X())
-        // , cleanup_op(Op::X())
     {
-        auto barenco_cfg = config.find("barenco_cfg");
+        auto barenco_cfg = config.find("barenco_decomp");
         if (barenco_cfg != config.end()) {
             if (barenco_cfg->contains("controls_threshold")) {
                 controls_threshold = barenco_cfg->at("controls_threshold");
+            }
+            if (barenco_cfg->contains("use_relative_phase")) {
+                bool use_relative_phase = barenco_cfg->at("use_relative_phase");
+                if (!use_relative_phase) {
+                    compute_op = Op::X();
+                    cleanup_op = Op::X();
+                }
             }
         }
         if (config.contains("max_qubits")) {
@@ -41,25 +44,27 @@ struct Config {
     }
 };
 
-inline std::vector<Qubit> get_workspace(Circuit& circuit, std::vector<Qubit> const& qubits, Config const& cfg)
+inline std::vector<Qubit> get_workspace(Circuit& circuit,
+    std::vector<Qubit> const& qubits, Config const& cfg)
 {
     std::vector<Qubit> workspace;
-    circuit.foreach_qubit([&](Qubit ref) {
-        // if (cfg.locked[ref]) {
-        if (cfg.locked == ref) {
+    circuit.foreach_qubit([&](Qubit current_qubit) {
+        if (cfg.locked == current_qubit) {
             return;
         }
         for (Qubit qubit : qubits) {
-            if (ref.uid() == qubit.uid()) {
+            if (current_qubit.uid() == qubit.uid()) {
                 return;
             }
         }
-        workspace.push_back(ref);
+        workspace.push_back(current_qubit);
     });
     return workspace;
 }
 
-inline void v_dirty(Circuit& circuit, Operator const& op, std::vector<Qubit> const& qubits, Config const& cfg)
+inline void v_dirty(Circuit& circuit, Operator const& op,
+    std::vector<Qubit> const& qubits, std::vector<Cbit> const& cbits, 
+    Config const& cfg)
 {
     uint32_t const num_controls = qubits.size() - 1;
     std::vector<Qubit> workspace = get_workspace(circuit, qubits, cfg);
@@ -73,21 +78,25 @@ inline void v_dirty(Circuit& circuit, Operator const& op, std::vector<Qubit> con
             Qubit const c0 = qubits.at(num_controls - 1 - i);
             Qubit const c1 = workspace.at(workspace_size - 1 - i);
             Qubit const t = workspace.at(workspace_size - i);
-            circuit.apply_operator(i ? cfg.compute_op : op, {c0, c1, t});
+            circuit.apply_operator(i ? cfg.compute_op : op, {c0, c1, t}, cbits);
         }
 
-        circuit.apply_operator(offset ? cfg.cleanup_op : cfg.compute_op, {qubits[0], qubits[1], workspace[workspace_size - (num_controls - 2)]});
+        circuit.apply_operator(offset ? cfg.cleanup_op : cfg.compute_op,
+            {qubits[0], qubits[1], workspace[workspace_size - (num_controls - 2)]},
+            cbits);
 
         for (int i = num_controls - 2 - 1; i >= offset; --i) {
             Qubit const c0 = qubits.at(num_controls - 1 - i);
             Qubit const c1 = workspace.at(workspace_size - 1 - i);
             Qubit const t = workspace.at(workspace_size - i);
-            circuit.apply_operator(i ? cfg.cleanup_op : op, {c0, c1, t});
+            circuit.apply_operator(i ? cfg.cleanup_op : op, {c0, c1, t}, cbits);
         }
     }
 }
 
-inline void v_clean(Circuit& circuit, Operator const& op, std::vector<Qubit> const& qubits, Config const& cfg)
+inline void v_clean(Circuit& circuit, Operator const& op,
+    std::vector<Qubit> const& qubits, std::vector<Cbit> const& cbits, 
+    Config const& cfg)
 {
     uint32_t const num_controls = qubits.size() - 1;
     std::vector<Qubit> ancillae;
@@ -98,27 +107,35 @@ inline void v_clean(Circuit& circuit, Operator const& op, std::vector<Qubit> con
     circuit.apply_operator(cfg.compute_op, {qubits[0], qubits[1], ancillae.at(0)});
     uint32_t j = 0;
     for (uint32_t i = 2; i < (num_controls - 1); ++i) {
-        circuit.apply_operator(cfg.compute_op, {qubits.at(i), ancillae.at(j), ancillae.at(j + 1)});
+        circuit.apply_operator(cfg.compute_op,
+                               {qubits.at(i), ancillae.at(j), ancillae.at(j + 1)},
+                               cbits);
         j += 1;
     }
 
-    circuit.apply_operator(op, {qubits.at(num_controls - 1), ancillae.back(), qubits.back()});
+    circuit.apply_operator(
+        op, {qubits.at(num_controls - 1), ancillae.back(), qubits.back()}, cbits);
 
     for (uint32_t i = (num_controls - 1); i --> 2;) {
-        circuit.apply_operator(cfg.cleanup_op, {qubits.at(i), ancillae.at(j - 1), ancillae.at(j)});
+        circuit.apply_operator(cfg.cleanup_op, 
+                               {qubits.at(i), ancillae.at(j - 1), ancillae.at(j)},
+                               cbits);
         j -= 1;
     }
-    circuit.apply_operator(cfg.cleanup_op, {qubits[0], qubits[1], ancillae.at(0)});
-    for (Qubit const ref : ancillae) {
-        circuit.release_ancilla(ref);
+    circuit.apply_operator(cfg.cleanup_op,
+                           {qubits[0], qubits[1], ancillae.at(0)}, cbits);
+    for (Qubit const qubit : ancillae) {
+        circuit.release_ancilla(qubit);
     }
 }
 
-inline void dirty_ancilla(Circuit& circuit, Operator const& op, std::vector<Qubit> const& qubits, Config const& cfg)
+inline void dirty_ancilla(Circuit& circuit, Operator const& op,
+    std::vector<Qubit> const& qubits, std::vector<Cbit> const& cbits,
+    Config const& cfg)
 {
     uint32_t const num_controls = qubits.size() - 1;
     if (num_controls <= cfg.controls_threshold) {
-        circuit.apply_operator(op, qubits);
+        circuit.apply_operator(op, qubits, cbits);
         return;
     }
 
@@ -128,7 +145,7 @@ inline void dirty_ancilla(Circuit& circuit, Operator const& op, std::vector<Qubi
     // n is the number of qubits
     // m is the number of controls
     if (circuit.num_qubits() + 1 >= (num_controls << 1)) {
-        v_dirty(circuit, op, qubits, cfg);
+        v_dirty(circuit, op, qubits, cbits, cfg);
         return;
     }
 
@@ -149,13 +166,15 @@ inline void dirty_ancilla(Circuit& circuit, Operator const& op, std::vector<Qubi
     qubits0.push_back(free_qubit);
     qubits1.push_back(free_qubit);
     qubits1.push_back(qubits.back());
-    dirty_ancilla(circuit, cfg.compute_op, qubits0, cfg);
-    dirty_ancilla(circuit, op, qubits1, cfg);
-    dirty_ancilla(circuit, cfg.cleanup_op, qubits0, cfg);
-    dirty_ancilla(circuit, op, qubits1, cfg);
+    dirty_ancilla(circuit, cfg.compute_op, qubits0, cbits, cfg);
+    dirty_ancilla(circuit, op, qubits1, cbits, cfg);
+    dirty_ancilla(circuit, cfg.cleanup_op, qubits0, cbits, cfg);
+    dirty_ancilla(circuit, op, qubits1, cbits, cfg);
 }
 
-inline void clean_ancilla(Circuit& circuit, Operator const& op, std::vector<Qubit> const& qubits, Config& cfg)
+inline void clean_ancilla(Circuit& circuit, Operator const& op,
+    std::vector<Qubit> const& qubits, std::vector<Cbit> const& cbits, 
+    Config const& cfg)
 {
     uint32_t const num_controls = qubits.size() - 1;
     if (num_controls <= cfg.controls_threshold) {
@@ -169,7 +188,7 @@ inline void clean_ancilla(Circuit& circuit, Operator const& op, std::vector<Qubi
     // n is the number of qubits
     // m is the number of controls
     if (circuit.num_qubits() + 1 >= (num_controls << 1)) {
-        v_dirty(circuit, op, qubits, cfg);
+        v_dirty(circuit, op, qubits, cbits, cfg);
         return;
     }
 
@@ -186,15 +205,13 @@ inline void clean_ancilla(Circuit& circuit, Operator const& op, std::vector<Qubi
         qubits1.push_back(qubits[i]);
     }
     if (circuit.num_ancillae() > 0) {
-        // fmt::print("b\n");
         Qubit ancilla = circuit.request_ancilla();
-        // cfg.locked[ancilla] = 1;
         qubits0.push_back(ancilla);
         qubits1.push_back(ancilla);
         qubits1.push_back(qubits.back());
-        clean_ancilla(circuit, cfg.compute_op, qubits0, cfg);
-        clean_ancilla(circuit, op, qubits1, cfg);
-        clean_ancilla(circuit, cfg.cleanup_op, qubits0, cfg);
+        clean_ancilla(circuit, cfg.compute_op, qubits0, cbits, cfg);
+        clean_ancilla(circuit, op, qubits1, cbits, cfg);
+        clean_ancilla(circuit, cfg.cleanup_op, qubits0, cbits, cfg);
         circuit.release_ancilla(ancilla);
         return;
     }
@@ -203,77 +220,85 @@ inline void clean_ancilla(Circuit& circuit, Operator const& op, std::vector<Qubi
     qubits0.push_back(free_qubit);
     qubits1.push_back(free_qubit);
     qubits1.push_back(qubits.back());
-    dirty_ancilla(circuit, cfg.compute_op, qubits0, cfg);
-    dirty_ancilla(circuit, op, qubits1, cfg);
-    dirty_ancilla(circuit, cfg.cleanup_op, qubits0, cfg);
-    dirty_ancilla(circuit, op, qubits1, cfg);
+    dirty_ancilla(circuit, cfg.compute_op, qubits0, cbits, cfg);
+    dirty_ancilla(circuit, op, qubits1, cbits, cfg);
+    dirty_ancilla(circuit, cfg.cleanup_op, qubits0, cbits, cfg);
+    dirty_ancilla(circuit, op, qubits1, cbits, cfg);
 }
 
 inline bool decompose(Circuit& circuit, Instruction const& inst, Config& cfg)
 {
-    // cfg.locked[inst.target()] = 1;
     cfg.locked = inst.target();
     if (inst.num_qubits() == circuit.num_qubits()) {
         circuit.create_ancilla();
-        // cfg.locked.push_back(0);
     }
     if (inst.num_controls() == 3u && circuit.num_ancillae() > 0) {
         Qubit ancilla = circuit.request_ancilla();
-        circuit.apply_operator(cfg.compute_op, {inst.control(0), inst.control(1), ancilla});
-        circuit.apply_operator(inst, {inst.control(2), ancilla, inst.target()});
-        circuit.apply_operator(cfg.cleanup_op, {inst.control(0), inst.control(1), ancilla});
+        circuit.apply_operator(cfg.compute_op,
+                               {inst.control(0), inst.control(1), ancilla},
+                               inst.cbits());
+        circuit.apply_operator(inst,
+                               {inst.control(2), ancilla, inst.target()},
+                               inst.cbits());
+        circuit.apply_operator(cfg.cleanup_op,
+                               {inst.control(0), inst.control(1), ancilla},
+                               inst.cbits());
         circuit.release_ancilla(ancilla);
         return true;
     }
     if (circuit.num_ancillae() == 0 && circuit.num_qubits() >= cfg.max_qubits) {
-        dirty_ancilla(circuit, inst, inst.qubits(), cfg);
+        dirty_ancilla(circuit, inst, inst.qubits(), inst.cbits(), cfg);
         return true;
     }
     for (uint32_t i = circuit.num_qubits(); i < cfg.max_qubits && circuit.num_ancillae() < (inst.num_controls() - 2); ++i) {
         circuit.create_ancilla();
     }
     if (circuit.num_ancillae() >= (inst.num_controls() - 2)) {
-        v_clean(circuit, inst, inst.qubits(), cfg);
+        v_clean(circuit, inst, inst.qubits(), inst.cbits(), cfg);
     } else {
-        clean_ancilla(circuit, inst, inst.qubits(), cfg);
+        clean_ancilla(circuit, inst, inst.qubits(), inst.cbits(), cfg);
     }
     return true;
 }
 
 }
 
-void barenco_decomp(Circuit& circuit, Instruction const& inst, nlohmann::json const& config)
+void barenco_decomp(Circuit& circuit, Instruction const& inst,
+    nlohmann::json const& config)
 {
-    Config cfg(circuit.num_qubits(), config);
+    Config cfg(config);
     decompose(circuit, inst, cfg);
 }
 
-void barenco_decomp(Circuit& circuit, Circuit const& original, nlohmann::json const& config)
+void barenco_decomp(Circuit& decomposed, Circuit const& original,
+    nlohmann::json const& config)
 {
-    Config cfg(original.num_qubits(), config);
+    Config cfg(config);
     original.foreach_instruction([&](Instruction const& inst) {
-        // Only X, Y, Z
-        if (inst.is_one<Op::X, Op::Y, Op::Z>() && inst.num_controls() > cfg.controls_threshold) {
-            decompose(circuit, inst, cfg);
-            return;
+        if (inst.is_one<Op::X, Op::Y, Op::Z>()) {
+            if (inst.num_controls() > cfg.controls_threshold) {
+                decompose(decomposed, inst, cfg);
+                return;
+            }
         }
-        circuit.apply_operator(inst);
+        decomposed.apply_operator(inst);
     });
 }
 
 Circuit barenco_decomp(Circuit const& original, nlohmann::json const& config)
 {
-    Config cfg(original.num_qubits(), config);
-    Circuit result = shallow_duplicate(original);
+    Config cfg(config);
+    Circuit decomposed = shallow_duplicate(original);
     original.foreach_instruction([&](Instruction const& inst) {
-        // Only X, Y, Z
-        if (inst.is_one<Op::X, Op::Y, Op::Z>() && inst.num_controls() > cfg.controls_threshold) {
-            decompose(result, inst, cfg);
-            return;
+        if (inst.is_one<Op::X, Op::Y, Op::Z>()) {
+            if (inst.num_controls() > cfg.controls_threshold) {
+                decompose(decomposed, inst, cfg);
+                return;
+            }
         }
-        result.apply_operator(inst);
+        decomposed.apply_operator(inst);
     });
-    return result;
+    return decomposed;
 }
 
 } // namespace tweedledum

--- a/lib/Passes/Decomposition/euler_decomp.cpp
+++ b/lib/Passes/Decomposition/euler_decomp.cpp
@@ -27,7 +27,7 @@ struct Config {
     Config(nlohmann::json const& config)
         : basis(Basis::zyz)
     {
-        auto euler_cfg = config.find("euler_cfg");
+        auto euler_cfg = config.find("euler_decomp");
         if (euler_cfg != config.end()) {
             if (euler_cfg->contains("basis")) {
                 if (euler_cfg->at("basis") == "zyz") {
@@ -68,16 +68,16 @@ inline bool decompose(Circuit& circuit, Instruction const& inst, Config& cfg)
         params.lambda += -sym_angle::pi_half;
         params.phi += sym_angle::pi_half;
     }
-    circuit.apply_operator(Op::Rz(params.lambda), inst.qubits());
+    circuit.apply_operator(Op::Rz(params.lambda), inst.qubits(), inst.cbits());
     switch (cfg.basis) {
         case Config::Basis::zxz:
-            circuit.apply_operator(Op::Rx(params.theta), inst.qubits());
+            circuit.apply_operator(Op::Rx(params.theta), inst.qubits(), inst.cbits());
             break;
         case Config::Basis::zyz:
-            circuit.apply_operator(Op::Ry(params.theta), inst.qubits());
+            circuit.apply_operator(Op::Ry(params.theta), inst.qubits(), inst.cbits());
             break;
     }
-    circuit.apply_operator(Op::Rz(params.phi), inst.qubits());
+    circuit.apply_operator(Op::Rz(params.phi), inst.qubits(), inst.cbits());
     circuit.global_phase() += params.phase;
     return true;
 }
@@ -93,15 +93,15 @@ void euler_decomp(Circuit& circuit, Instruction const& inst, nlohmann::json cons
 Circuit euler_decomp(Circuit const& original, nlohmann::json const& config)
 {
     Config cfg(config);
-    Circuit result = shallow_duplicate(original);
+    Circuit decomposed = shallow_duplicate(original);
     original.foreach_instruction([&](Instruction const& inst) {
         if (inst.is_a<Op::Unitary>() && inst.num_qubits() == 1u) {
-            decompose(result, inst, cfg);
+            decompose(decomposed, inst, cfg);
             return;
         }
-        result.apply_operator(inst);
+        decomposed.apply_operator(inst);
     });
-    return result;
+    return decomposed;
 }
 
 } // namespace tweedledum

--- a/lib/Passes/Decomposition/parity_decomp.cpp
+++ b/lib/Passes/Decomposition/parity_decomp.cpp
@@ -14,7 +14,7 @@ namespace {
 
 inline bool decompose(Circuit& circuit, Instruction const& inst)
 {
-    inst.foreach_control([&](WireRef wref) {
+    inst.foreach_control([&](Qubit wref) {
         circuit.apply_operator(Op::X(), {wref, inst.target()});
     });
     return true;

--- a/lib/Passes/Decomposition/parity_decomp.cpp
+++ b/lib/Passes/Decomposition/parity_decomp.cpp
@@ -14,8 +14,8 @@ namespace {
 
 inline bool decompose(Circuit& circuit, Instruction const& inst)
 {
-    inst.foreach_control([&](Qubit wref) {
-        circuit.apply_operator(Op::X(), {wref, inst.target()});
+    inst.foreach_control([&](Qubit qubit) {
+        circuit.apply_operator(Op::X(), {qubit, inst.target()}, inst.cbits());
     });
     return true;
 }
@@ -29,15 +29,15 @@ void parity_decomp(Circuit& circuit, Instruction const& inst)
 
 Circuit parity_decomp(Circuit const& original)
 {
-    Circuit result = shallow_duplicate(original);
+    Circuit decomposed = shallow_duplicate(original);
     original.foreach_instruction([&](Instruction const& inst) {
         if (inst.is_a<Op::Parity>()) {
-            decompose(result, inst);
+            decompose(decomposed, inst);
             return;
         }
-        result.apply_operator(inst);
+        decomposed.apply_operator(inst);
     });
-    return result;
+    return decomposed;
 }
 
 } // namespace tweedledum

--- a/lib/Passes/Mapping/Placer/LinePlacer.cpp
+++ b/lib/Passes/Mapping/Placer/LinePlacer.cpp
@@ -26,8 +26,8 @@ void LinePlacer::partition_into_timeframes()
             frame.at(ref) = max_timeframe;
         } else {
             frame.at(ref) = ++max_timeframe;
-            uint32_t const control = state_.wire_to_v.at(inst.qubit(0));
-            uint32_t const target = state_.wire_to_v.at(inst.qubit(1));
+            uint32_t const control = inst.qubit(0);
+            uint32_t const target = inst.qubit(1);
             if (max_timeframe == timeframes_.size()) {
                 timeframes_.emplace_back();
             }
@@ -137,8 +137,8 @@ void LinePlacer::place_lines()
         }
     }
     for (std::vector<uint32_t> const& line : lines_) {
-        state_.phy_to_v.at(max_degree_phy) = state_.mapped.wire_ref(line.at(0));
-        state_.v_to_phy.at(line.at(0)) = state_.mapped.wire_ref(max_degree_phy);
+        state_.phy_to_v.at(max_degree_phy) = state_.mapped.qubit_ref(line.at(0));
+        state_.v_to_phy.at(line.at(0)) = state_.mapped.qubit_ref(max_degree_phy);
         // --phy_degree_.at(max_degree_phy);
         phy_degree_.at(max_degree_phy) = 0;
         for (uint32_t i = 1u; i < line.size(); ++i) {
@@ -146,8 +146,8 @@ void LinePlacer::place_lines()
             if (neighbor == -1) {
                 break;
             }
-            state_.phy_to_v.at(neighbor) = state_.mapped.wire_ref(line.at(i));
-            state_.v_to_phy.at(line.at(i)) = state_.mapped.wire_ref(neighbor);
+            state_.phy_to_v.at(neighbor) = state_.mapped.qubit_ref(line.at(i));
+            state_.v_to_phy.at(line.at(i)) = state_.mapped.qubit_ref(neighbor);
             // --phy_degree_.at(neighbor);
             phy_degree_.at(neighbor) = 0;
         }

--- a/lib/Passes/Mapping/Placer/LinePlacer.cpp
+++ b/lib/Passes/Mapping/Placer/LinePlacer.cpp
@@ -113,7 +113,7 @@ int LinePlacer::pick_neighbor(uint32_t const phy) const
 {
     int max_degree_neighbor = -1;
     state_.device.foreach_neighbor(phy, [&](uint32_t const neighbor) {
-        if (state_.phy_to_v.at(neighbor) != WireRef::invalid()) {
+        if (state_.phy_to_v.at(neighbor) != Qubit::invalid()) {
             return;
         }
         if (max_degree_neighbor == -1) {
@@ -137,8 +137,8 @@ void LinePlacer::place_lines()
         }
     }
     for (std::vector<uint32_t> const& line : lines_) {
-        state_.phy_to_v.at(max_degree_phy) = state_.mapped.qubit_ref(line.at(0));
-        state_.v_to_phy.at(line.at(0)) = state_.mapped.qubit_ref(max_degree_phy);
+        state_.phy_to_v.at(max_degree_phy) = state_.mapped.qubit(line.at(0));
+        state_.v_to_phy.at(line.at(0)) = state_.mapped.qubit(max_degree_phy);
         // --phy_degree_.at(max_degree_phy);
         phy_degree_.at(max_degree_phy) = 0;
         for (uint32_t i = 1u; i < line.size(); ++i) {
@@ -146,13 +146,13 @@ void LinePlacer::place_lines()
             if (neighbor == -1) {
                 break;
             }
-            state_.phy_to_v.at(neighbor) = state_.mapped.qubit_ref(line.at(i));
-            state_.v_to_phy.at(line.at(i)) = state_.mapped.qubit_ref(neighbor);
+            state_.phy_to_v.at(neighbor) = state_.mapped.qubit(line.at(i));
+            state_.v_to_phy.at(line.at(i)) = state_.mapped.qubit(neighbor);
             // --phy_degree_.at(neighbor);
             phy_degree_.at(neighbor) = 0;
         }
         for (uint32_t i = 0u; i < phy_degree_.size(); ++i) {
-            // if (state_.phy_to_v.at(i) != WireRef::invalid()) {
+            // if (state_.phy_to_v.at(i) != Qubit::invalid()) {
             //     continue;
             // }
             if (phy_degree_.at(max_degree_phy) < phy_degree_.at(i)) {

--- a/lib/Passes/Mapping/Placer/SabrePlacer.cpp
+++ b/lib/Passes/Mapping/Placer/SabrePlacer.cpp
@@ -92,11 +92,9 @@ bool SabrePlacer::add_instruction(Instruction const& inst)
 {
     assert(inst.num_qubits() && inst.num_qubits() <= 2u);
     // Transform the wires to a new
-    SmallVector<WireRef, 2> qubits;
-    inst.foreach_wire([&](WireRef ref) {
-        if (ref.kind() == Wire::Kind::quantum) {
-            qubits.push_back(state_.v_to_phy.at(ref));
-        }
+    SmallVector<Qubit, 2> qubits;
+    inst.foreach_qubit([&](Qubit ref) {
+        qubits.push_back(state_.v_to_phy.at(ref));
     });
 
     if (inst.num_qubits() == 1) {
@@ -109,7 +107,7 @@ bool SabrePlacer::add_instruction(Instruction const& inst)
     return true;
 }
 
-void SabrePlacer::add_swap(WireRef const phy0, WireRef const phy1)
+void SabrePlacer::add_swap(Qubit const phy0, Qubit const phy1)
 {
     fmt::print("Add swap: {} <-> {}\n", phy0, phy1);
     state_.swap_qubits(phy0, phy1);
@@ -122,7 +120,7 @@ SabrePlacer::Swap SabrePlacer::find_swap()
     for (uint32_t i = 0u; i < state_.device.num_edges(); ++i) {
         auto const& [u, v] = state_.device.edge(i);
         if (involved_phy_.at(u) || involved_phy_.at(v)) {
-            swap_candidates.emplace_back(state_.mapped.qubit_ref(u), state_.mapped.qubit_ref(v));
+            swap_candidates.emplace_back(state_.mapped.qubit(u), state_.mapped.qubit(v));
         }
     }
 
@@ -133,7 +131,7 @@ SabrePlacer::Swap SabrePlacer::find_swap()
     // Compute cost
     std::vector<double> cost;
     for (auto const& [phy0, phy1] : swap_candidates) {
-        std::vector<WireRef> v_to_phy = state_.v_to_phy;
+        std::vector<Qubit> v_to_phy = state_.v_to_phy;
         std::swap(v_to_phy.at(state_.phy_to_v.at(phy0)), v_to_phy.at(state_.phy_to_v.at(phy1)));
         double swap_cost = compute_cost(v_to_phy, front_layer_);
         double const max_decay = std::max(phy_decay_.at(phy0), phy_decay_.at(phy1));
@@ -157,13 +155,13 @@ SabrePlacer::Swap SabrePlacer::find_swap()
     return swap_candidates.at(min);
 }
 
-double SabrePlacer::compute_cost(std::vector<WireRef> const& v_to_phy, std::vector<InstRef> const& layer)
+double SabrePlacer::compute_cost(std::vector<Qubit> const& v_to_phy, std::vector<InstRef> const& layer)
 {
     double cost = 0.0;
     for (InstRef ref : layer) {
         Instruction const& inst = current_->instruction(ref);
-        WireRef const v0 = inst.qubit(0);
-        WireRef const v1 = inst.qubit(1);
+        Qubit const v0 = inst.qubit(0);
+        Qubit const v1 = inst.qubit(1);
         cost += (state_.device.distance(v_to_phy.at(v0), v_to_phy.at(v1)) - 1);
     }
     return cost;

--- a/lib/Passes/Mapping/Placer/SabrePlacer.cpp
+++ b/lib/Passes/Mapping/Placer/SabrePlacer.cpp
@@ -42,8 +42,8 @@ bool SabrePlacer::add_front_layer()
         if (add_instruction(inst) == false) {
                 new_front_layer.push_back(ref);
                 auto const qubits = inst.qubits();
-                involved_phy_.at(state_.wire_to_wire(qubits.at(0))) = 1u;
-                involved_phy_.at(state_.wire_to_wire(qubits.at(1))) = 1u;
+                involved_phy_.at(state_.v_to_phy.at(qubits.at(0))) = 1u;
+                involved_phy_.at(state_.v_to_phy.at(qubits.at(1))) = 1u;
                 continue;
         }
         added_at_least_one = true;
@@ -95,7 +95,7 @@ bool SabrePlacer::add_instruction(Instruction const& inst)
     SmallVector<WireRef, 2> qubits;
     inst.foreach_wire([&](WireRef ref) {
         if (ref.kind() == Wire::Kind::quantum) {
-            qubits.push_back(state_.wire_to_wire(ref));
+            qubits.push_back(state_.v_to_phy.at(ref));
         }
     });
 
@@ -122,7 +122,7 @@ SabrePlacer::Swap SabrePlacer::find_swap()
     for (uint32_t i = 0u; i < state_.device.num_edges(); ++i) {
         auto const& [u, v] = state_.device.edge(i);
         if (involved_phy_.at(u) || involved_phy_.at(v)) {
-            swap_candidates.emplace_back(state_.mapped.wire_ref(u), state_.mapped.wire_ref(v));
+            swap_candidates.emplace_back(state_.mapped.qubit_ref(u), state_.mapped.qubit_ref(v));
         }
     }
 
@@ -162,8 +162,8 @@ double SabrePlacer::compute_cost(std::vector<WireRef> const& v_to_phy, std::vect
     double cost = 0.0;
     for (InstRef ref : layer) {
         Instruction const& inst = current_->instruction(ref);
-        WireRef const v0 = state_.wire_to_v.at(inst.qubit(0));
-        WireRef const v1 = state_.wire_to_v.at(inst.qubit(1));
+        WireRef const v0 = inst.qubit(0);
+        WireRef const v1 = inst.qubit(1);
         cost += (state_.device.distance(v_to_phy.at(v0), v_to_phy.at(v1)) - 1);
     }
     return cost;

--- a/lib/Passes/Mapping/Router/JITRouter.cpp
+++ b/lib/Passes/Mapping/Router/JITRouter.cpp
@@ -89,22 +89,22 @@ undo_increment:
     }
 }
 
-std::vector<WireRef> JITRouter::find_free_phy() const
+std::vector<Qubit> JITRouter::find_free_phy() const
 {
-    std::vector<WireRef> free_phy;
+    std::vector<Qubit> free_phy;
     for (uint32_t i = 0; i < state_.phy_to_v.size(); ++i) {
-        if (state_.phy_to_v.at(i) == WireRef::invalid()) {
-            free_phy.push_back(state_.mapped.qubit_ref(i));
+        if (state_.phy_to_v.at(i) == Qubit::invalid()) {
+            free_phy.push_back(state_.mapped.qubit(i));
         }
     }
     return free_phy;
 }
     
-void JITRouter::place_two_v(WireRef const v0, WireRef const v1)
+void JITRouter::place_two_v(Qubit const v0, Qubit const v1)
 {
-    WireRef phy0 = state_.v_to_phy.at(v0);
-    WireRef phy1 = state_.v_to_phy.at(v1);
-    std::vector<WireRef> const free_phy = find_free_phy();
+    Qubit phy0 = state_.v_to_phy.at(v0);
+    Qubit phy1 = state_.v_to_phy.at(v1);
+    std::vector<Qubit> const free_phy = find_free_phy();
     assert(free_phy.size() >= 2u);
     if (free_phy.size() == 2u) {
         phy0 = free_phy.at(0);
@@ -113,8 +113,8 @@ void JITRouter::place_two_v(WireRef const v0, WireRef const v1)
         uint32_t min_dist = std::numeric_limits<uint32_t>::max();
         for (uint32_t i = 0u; i < free_phy.size(); ++i) {
             for (uint32_t j = i + 1u; j < free_phy.size(); ++j) {
-                WireRef const i_phy = free_phy.at(i);
-                WireRef const j_phy = free_phy.at(j);
+                Qubit const i_phy = free_phy.at(i);
+                Qubit const j_phy = free_phy.at(j);
                 if (min_dist < state_.device.distance(i_phy, j_phy)) {
                     continue;
                 }
@@ -132,13 +132,13 @@ void JITRouter::place_two_v(WireRef const v0, WireRef const v1)
     add_delayed(v1);
 }
 
-void JITRouter::place_one_v(WireRef v0, WireRef v1)
+void JITRouter::place_one_v(Qubit v0, Qubit v1)
 {
-    WireRef phy0 = state_.v_to_phy.at(v0);
-    WireRef phy1 = state_.v_to_phy.at(v1);
-    std::vector<WireRef> const free_phy = find_free_phy();
+    Qubit phy0 = state_.v_to_phy.at(v0);
+    Qubit phy1 = state_.v_to_phy.at(v1);
+    std::vector<Qubit> const free_phy = find_free_phy();
     assert(free_phy.size() >= 1u);
-    if (phy1 == WireRef::invalid()) {
+    if (phy1 == Qubit::invalid()) {
         std::swap(v0, v1);
         std::swap(phy0, phy1);
     }
@@ -156,7 +156,7 @@ void JITRouter::place_one_v(WireRef v0, WireRef v1)
 }
 
 //FIXME: need take care of wires
-void JITRouter::add_delayed(WireRef const v)
+void JITRouter::add_delayed(Qubit const v)
 {
     assert(v < delayed_.size());
     for (InstRef ref : delayed_.at(v)) {
@@ -168,9 +168,9 @@ void JITRouter::add_delayed(WireRef const v)
 
 void JITRouter::add_instruction(Instruction const& inst)
 {
-    std::vector<WireRef> new_wires;
+    std::vector<Qubit> new_wires;
     new_wires.reserve(inst.num_wires());
-    inst.foreach_wire([&](WireRef ref) {
+    inst.foreach_qubit([&](Qubit ref) {
         new_wires.push_back(state_.v_to_phy.at(ref));
     });
     state_.mapped.apply_operator(inst, new_wires);
@@ -180,16 +180,14 @@ bool JITRouter::try_add_instruction(InstRef ref, Instruction const& inst)
 {
     assert(inst.num_qubits() && inst.num_qubits() <= 2u);
     // Transform the wires to a new
-    SmallVector<WireRef, 2> qubits;
-    inst.foreach_wire([&](WireRef ref) {
-        if (ref.kind() == Wire::Kind::quantum) {
-            qubits.push_back(ref);
-        }
+    SmallVector<Qubit, 2> qubits;
+    inst.foreach_qubit([&](Qubit ref) {
+        qubits.push_back(ref);
     });
 
-    WireRef phy0 = state_.v_to_phy.at(qubits[0]);
+    Qubit phy0 = state_.v_to_phy.at(qubits[0]);
     if (inst.num_qubits() == 1) {
-        if (phy0 == WireRef::invalid()) {
+        if (phy0 == Qubit::invalid()) {
             delayed_.at(qubits[0]).push_back(ref);
         } else {
             add_instruction(inst);
@@ -197,10 +195,10 @@ bool JITRouter::try_add_instruction(InstRef ref, Instruction const& inst)
         return true;
     }
     // FIXME: implement .at in SmallVector!
-    WireRef phy1 = state_.v_to_phy.at(qubits[1]);
-    if (phy0 == WireRef::invalid() && phy1 == WireRef::invalid()) {
+    Qubit phy1 = state_.v_to_phy.at(qubits[1]);
+    if (phy0 == Qubit::invalid() && phy1 == Qubit::invalid()) {
         place_two_v(qubits[0], qubits[1]);
-    } else if (phy0 == WireRef::invalid() || phy1 == WireRef::invalid()) {
+    } else if (phy0 == Qubit::invalid() || phy1 == Qubit::invalid()) {
         place_one_v(qubits[0], qubits[1]);
     }
     phy0 = state_.v_to_phy.at(qubits[0]);
@@ -212,7 +210,7 @@ bool JITRouter::try_add_instruction(InstRef ref, Instruction const& inst)
     return true;
 }
 
-void JITRouter::add_swap(WireRef const phy0, WireRef const phy1)
+void JITRouter::add_swap(Qubit const phy0, Qubit const phy1)
 {
     state_.swap_qubits(phy0, phy1);
     mapped_->apply_operator(Op::Swap(), {phy0, phy1});
@@ -225,7 +223,7 @@ JITRouter::Swap JITRouter::find_swap()
     for (uint32_t i = 0u; i < state_.device.num_edges(); ++i) {
         auto const& [u, v] = state_.device.edge(i);
         if (involved_phy_.at(u) || involved_phy_.at(v)) {
-            swap_candidates.emplace_back(state_.mapped.qubit_ref(u), state_.mapped.qubit_ref(v));
+            swap_candidates.emplace_back(state_.mapped.qubit(u), state_.mapped.qubit(v));
         }
     }
 
@@ -236,13 +234,13 @@ JITRouter::Swap JITRouter::find_swap()
     // Compute cost
     std::vector<double> cost;
     for (auto const& [phy0, phy1] : swap_candidates) {
-        std::vector<WireRef> v_to_phy = state_.v_to_phy;
-        WireRef const v0 = state_.phy_to_v.at(phy0);
-        WireRef const v1 = state_.phy_to_v.at(phy1);
-        if (v0 != WireRef::invalid()) {
+        std::vector<Qubit> v_to_phy = state_.v_to_phy;
+        Qubit const v0 = state_.phy_to_v.at(phy0);
+        Qubit const v1 = state_.phy_to_v.at(phy1);
+        if (v0 != Qubit::invalid()) {
             v_to_phy.at(v0) = phy1;
         }
-        if (v1 != WireRef::invalid()) {
+        if (v1 != Qubit::invalid()) {
             v_to_phy.at(v1) = phy0;
         }
         double swap_cost = compute_cost(v_to_phy, front_layer_);
@@ -267,16 +265,16 @@ JITRouter::Swap JITRouter::find_swap()
     return swap_candidates.at(min);
 }
 
-double JITRouter::compute_cost(std::vector<WireRef> const& v_to_phy, std::vector<InstRef> const& layer)
+double JITRouter::compute_cost(std::vector<Qubit> const& v_to_phy, std::vector<InstRef> const& layer)
 {
     double cost = 0.0;
     for (InstRef ref : layer) {
         Instruction const& inst = state_.original.instruction(ref);
-        WireRef const v0 = inst.qubit(0);
-        WireRef const v1 = inst.qubit(1);
-        WireRef const phy0 = v_to_phy.at(v0);
-        WireRef const phy1 = v_to_phy.at(v1);
-        if (phy0 == WireRef::invalid() || phy1 == WireRef::invalid()) {
+        Qubit const v0 = inst.qubit(0);
+        Qubit const v1 = inst.qubit(1);
+        Qubit const phy0 = v_to_phy.at(v0);
+        Qubit const phy1 = v_to_phy.at(v1);
+        if (phy0 == Qubit::invalid() || phy1 == Qubit::invalid()) {
             continue;
         }
         cost += (state_.device.distance(phy0, phy1) - 1);

--- a/lib/Passes/Mapping/Router/JITRouter.cpp
+++ b/lib/Passes/Mapping/Router/JITRouter.cpp
@@ -173,7 +173,7 @@ void JITRouter::add_instruction(Instruction const& inst)
     inst.foreach_qubit([&](Qubit ref) {
         new_wires.push_back(state_.v_to_phy.at(ref));
     });
-    state_.mapped.apply_operator(inst, new_wires);
+    state_.mapped.apply_operator(inst, new_wires, inst.cbits());
 }
 
 bool JITRouter::try_add_instruction(InstRef ref, Instruction const& inst)

--- a/lib/Passes/Mapping/Router/SabreRouter.cpp
+++ b/lib/Passes/Mapping/Router/SabreRouter.cpp
@@ -103,14 +103,14 @@ bool SabreRouter::add_instruction(Instruction const& inst)
     });
 
     if (inst.num_qubits() == 1) {
-        state_.mapped.apply_operator(inst, new_wires);
+        state_.mapped.apply_operator(inst, new_wires, inst.cbits());
         return true;
     }
     // FIXME: implement .at in SmallVector!
     if (!state_.device.are_connected(qubits[0], qubits[1])) {
         return false;
     }
-    state_.mapped.apply_operator(inst, new_wires);
+    state_.mapped.apply_operator(inst, new_wires, inst.cbits());
     return true;
 }
 

--- a/lib/Passes/Mapping/Router/SabreRouter.cpp
+++ b/lib/Passes/Mapping/Router/SabreRouter.cpp
@@ -93,15 +93,13 @@ bool SabreRouter::add_instruction(Instruction const& inst)
 {
     assert(inst.num_qubits() && inst.num_qubits() <= 2u);
     // Transform the wires to a new
-    std::vector<WireRef> new_wires;
-    SmallVector<WireRef, 2> qubits;
+    std::vector<Qubit> new_wires;
+    SmallVector<Qubit, 2> qubits;
     new_wires.reserve(inst.num_wires());
-    inst.foreach_wire([&](WireRef ref) {
-        WireRef const new_wire = state_.v_to_phy.at(ref);
+    inst.foreach_qubit([&](Qubit ref) {
+        Qubit const new_wire = state_.v_to_phy.at(ref);
         new_wires.push_back(new_wire);
-        if (ref.kind() == Wire::Kind::quantum) {
-            qubits.push_back(new_wire);
-        }
+        qubits.push_back(new_wire);
     });
 
     if (inst.num_qubits() == 1) {
@@ -116,7 +114,7 @@ bool SabreRouter::add_instruction(Instruction const& inst)
     return true;
 }
 
-void SabreRouter::add_swap(WireRef const phy0, WireRef const phy1)
+void SabreRouter::add_swap(Qubit const phy0, Qubit const phy1)
 {
     state_.swap_qubits(phy0, phy1);
     state_.mapped.apply_operator(Op::Swap(), {phy0, phy1});
@@ -129,7 +127,7 @@ SabreRouter::Swap SabreRouter::find_swap()
     for (uint32_t i = 0u; i < state_.device.num_edges(); ++i) {
         auto const& [u, v] = state_.device.edge(i);
         if (involved_phy_.at(u) || involved_phy_.at(v)) {
-            swap_candidates.emplace_back(state_.mapped.qubit_ref(u), state_.mapped.qubit_ref(v));
+            swap_candidates.emplace_back(state_.mapped.qubit(u), state_.mapped.qubit(v));
         }
     }
 
@@ -140,7 +138,7 @@ SabreRouter::Swap SabreRouter::find_swap()
     // Compute cost
     std::vector<double> cost;
     for (auto const& [phy0, phy1] : swap_candidates) {
-        std::vector<WireRef> v_to_phy = state_.v_to_phy;
+        std::vector<Qubit> v_to_phy = state_.v_to_phy;
         std::swap(v_to_phy.at(state_.phy_to_v.at(phy0)), v_to_phy.at(state_.phy_to_v.at(phy1)));
         double swap_cost = compute_cost(v_to_phy, front_layer_);
         double const max_decay = std::max(phy_decay_.at(phy0), phy_decay_.at(phy1));
@@ -164,13 +162,13 @@ SabreRouter::Swap SabreRouter::find_swap()
     return swap_candidates.at(min);
 }
 
-double SabreRouter::compute_cost(std::vector<WireRef> const& v_to_phy, std::vector<InstRef> const& layer)
+double SabreRouter::compute_cost(std::vector<Qubit> const& v_to_phy, std::vector<InstRef> const& layer)
 {
     double cost = 0.0;
     for (InstRef ref : layer) {
         Instruction const& inst = state_.original.instruction(ref);
-        WireRef const v0 = inst.qubit(0);
-        WireRef const v1 = inst.qubit(1);
+        Qubit const v0 = inst.qubit(0);
+        Qubit const v1 = inst.qubit(1);
         cost += (state_.device.distance(v_to_phy.at(v0), v_to_phy.at(v1)) - 1);
     }
     return cost;

--- a/lib/Passes/Optimization/gate_cancellation.cpp
+++ b/lib/Passes/Optimization/gate_cancellation.cpp
@@ -1,0 +1,35 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#include "tweedledum/Passes/Optimization/gate_cancellation.h"
+#include "tweedledum/Passes/Utility/shallow_duplicate.h"
+
+#include <vector>
+
+namespace tweedledum {
+
+Circuit gate_cancellation(Circuit const& original)
+{
+    Circuit result = shallow_duplicate(original);
+    std::vector<uint32_t> visited(original.size(), 0);
+    original.foreach_instruction([&](InstRef ref, Instruction const& inst) {
+        std::vector<InstRef> children;
+        original.foreach_child(ref, [&](InstRef const cref) {
+            do {
+                if (visited.at(cref) == 1) {
+
+                }
+                // if (op.is_adjoint(ancestor.op) || op.is_dependent(ancestor.op)) {
+                //     children.emplace_back(circuit.id(ancestor));
+                //     return;
+                // }
+            } while (1);
+        });
+        // Check children
+        // Do remove
+    });
+    return result;
+}
+
+} // namespace tweedledum

--- a/lib/Passes/Optimization/linear_resynth.cpp
+++ b/lib/Passes/Optimization/linear_resynth.cpp
@@ -77,7 +77,7 @@ inline void resynth_slice(Circuit const& original, Slice const& slice,
         // Circuit linear = linear_synth(result, qubits, matrix, config);
         Circuit subcircuit = linear_synth(matrix, config);
         if (subcircuit.size() < num_cnot) {
-            result.append(subcircuit, qubits);
+            result.append(subcircuit, qubits, {});
         } else {
             for (InstRef index : slice.linear_gates) {
                 Instruction const& inst = original.instruction(index);

--- a/lib/Passes/Optimization/linear_resynth.cpp
+++ b/lib/Passes/Optimization/linear_resynth.cpp
@@ -24,7 +24,7 @@ inline std::vector<Slice> partition_into_silces(Circuit const& original)
     std::vector<Slice> slices;
     original.foreach_instruction([&](InstRef ref, Instruction const& inst) {
         uint32_t max = 0;
-        inst.foreach_wire([&](InstRef child) {
+        inst.foreach_qubit([&](InstRef child) {
             max = std::max(max, to_slice[child]);
         });
         to_slice[ref] = max;
@@ -50,10 +50,10 @@ inline void resynth_slice(Circuit const& original, Slice const& slice,
     if (!slice.linear_gates.empty()) {
         // Get the qubits
         std::vector<int32_t> to_id(original.num_wires(), -1);
-        std::vector<WireRef> qubits;
+        std::vector<Qubit> qubits;
         for (InstRef index : slice.linear_gates) {
             Instruction const& inst = original.instruction(index);
-            inst.foreach_wire([&](WireRef wref) {
+            inst.foreach_qubit([&](Qubit wref) {
                 if (to_id[wref] != -1) {
                     return;
                 }
@@ -67,7 +67,7 @@ inline void resynth_slice(Circuit const& original, Slice const& slice,
         for (InstRef index : slice.linear_gates) {
             Instruction const& inst = original.instruction(index);
             int32_t const target = to_id.at(inst.target());
-            inst.foreach_control([&](WireRef wref) {
+            inst.foreach_control([&](Qubit wref) {
                 int32_t const control = to_id.at(wref);
                 matrix.row(target) += matrix.row(control);
                 num_cnot += 1u;

--- a/lib/Passes/Optimization/phase_folding.cpp
+++ b/lib/Passes/Optimization/phase_folding.cpp
@@ -13,34 +13,29 @@ namespace tweedledum {
 Circuit phase_folding(Circuit const& original)
 {
     using ESOP = std::vector<uint32_t>;
-    constexpr uint32_t qid_max = std::numeric_limits<uint32_t>::max();
-
     Circuit optimized;
     uint32_t num_path_vars = 1u;
-    std::vector<uint32_t> wire_to_qid(original.num_wires(), qid_max);
     std::vector<ESOP> qubit_pathsum;
     std::vector<uint8_t> skipped(original.size(), 0);
 
-    original.foreach_wire([&](WireRef ref, Wire const& wire) {
-        if (ref.kind() == Wire::Kind::classical) {
-            optimized.create_cbit(wire.name);
-            return;
-        };
-        optimized.create_qubit(wire.name);
-        wire_to_qid.at(ref) = qubit_pathsum.size();
+    original.foreach_cbit([&](std::string_view name) {
+        optimized.create_cbit(name);
+    });
+    original.foreach_qubit([&](std::string_view name) {
+        optimized.create_qubit(name);
         qubit_pathsum.emplace_back(1u, (num_path_vars++ << 1));
     });
 
     LinearPP parities;
     original.foreach_instruction([&](InstRef ref, Instruction const& inst) {
-        uint32_t const t = wire_to_qid.at(inst.target(0u));
+        uint32_t const t = inst.target(0u);
         Angle const angle = rotation_angle(inst);
         if (inst.num_cbits() || (inst.num_qubits() > 2)) {
             goto new_vars_end;
         }
         if (inst.num_targets() == 2) {
             if (inst.is_one<Op::Swap>()) {
-                uint32_t const t1 = wire_to_qid.at(inst.target(1u));
+                uint32_t const t1 = inst.target(1u);
                 std::swap(qubit_pathsum.at(t), qubit_pathsum.at(t1));
                 return;
             }
@@ -55,7 +50,7 @@ Circuit phase_folding(Circuit const& original)
                 qubit_pathsum.at(t).insert(qubit_pathsum.at(t).begin(), 1u);
                 return;
             }
-            uint32_t c = wire_to_qid.at(inst.control());
+            uint32_t c = inst.control();
             std::vector<uint32_t> esop;
             std::set_symmetric_difference(qubit_pathsum.at(c).begin(),
                 qubit_pathsum.at(c).end(), qubit_pathsum.at(t).begin(),
@@ -70,8 +65,8 @@ Circuit phase_folding(Circuit const& original)
 
     new_vars_end:
         skipped.at(ref) = 1u;
-        inst.foreach_target([&](WireRef wref) {
-            uint32_t const qubit = wire_to_qid.at(wref); 
+        inst.foreach_target([&](Qubit wref) {
+            uint32_t const qubit = wref; 
             qubit_pathsum.at(qubit).clear();
             qubit_pathsum.at(qubit).emplace_back((num_path_vars++ << 1));
         });
@@ -84,8 +79,8 @@ Circuit phase_folding(Circuit const& original)
     
     original.foreach_instruction([&](InstRef ref, Instruction const& inst) {
         if (skipped.at(ref)) {
-            inst.foreach_target([&](WireRef wref) {
-                uint32_t const qubit = wire_to_qid.at(wref); 
+            inst.foreach_target([&](Qubit wref) {
+                uint32_t const qubit = wref; 
                 qubit_pathsum.at(qubit).clear();
                 qubit_pathsum.at(qubit).emplace_back((num_path_vars++ << 1));
             });
@@ -96,9 +91,9 @@ Circuit phase_folding(Circuit const& original)
             return;
         }
 
-        uint32_t const t = wire_to_qid.at(inst.target());
+        uint32_t const t = inst.target();
         if (inst.is_one<Op::Swap>()) {
-            uint32_t const t1 = wire_to_qid.at(inst.target(1u));
+            uint32_t const t1 = inst.target(1u);
             std::swap(qubit_pathsum.at(t), qubit_pathsum.at(t1));
         }
         if (inst.is_one<Op::X>()) {
@@ -108,7 +103,7 @@ Circuit phase_folding(Circuit const& original)
                 }
                 qubit_pathsum.at(t).insert(qubit_pathsum.at(t).begin(), 1u);
             } else {
-                uint32_t c = wire_to_qid.at(inst.control());
+                uint32_t c = inst.control();
                 std::vector<uint32_t> esop;
                 std::set_symmetric_difference(qubit_pathsum.at(c).begin(),
                     qubit_pathsum.at(c).end(), qubit_pathsum.at(t).begin(),

--- a/lib/Passes/Synthesis/all_linear_synth.cpp
+++ b/lib/Passes/Synthesis/all_linear_synth.cpp
@@ -11,7 +11,8 @@ namespace {
 
 // I added this level of indirection because I can implement this method with
 // other codes or just using binary sequence.
-inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits, LinearPP parities)
+inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
+    std::vector<Cbit> const& cbits, LinearPP parities)
 {
     // Generate Gray code
     std::vector<uint32_t> gray_code(1u << circuit.num_qubits());
@@ -27,53 +28,52 @@ inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits, Linea
         qubits_states[i] = (1u << i);
         auto angle = parities.extract_term(qubits_states[i]);
         if (angle != 0.0) {
-            circuit.apply_operator(Op::P(angle), {qubits[i]});
+            circuit.apply_operator(Op::P(angle), {qubits[i]}, cbits);
         }
     }
 
     for (uint32_t i = circuit.num_qubits() - 1; i > 0; --i) {
         for (uint32_t j = (1u << (i + 1)) - 1; j > (1u << i); --j) {
             uint32_t c0 = std::log2(gray_code[j] ^ gray_code[j - 1u]);
-            circuit.apply_operator(Op::X(), {qubits[c0], qubits[i]});
+            circuit.apply_operator(Op::X(), {qubits[c0], qubits[i]}, cbits);
 
             qubits_states[i] ^= qubits_states[c0];
             auto angle = parities.extract_term(qubits_states[i]);
             if (angle != 0.0) {
-                circuit.apply_operator(Op::P(angle), {qubits[i]});
+                circuit.apply_operator(Op::P(angle), {qubits[i]}, cbits);
             }
         }
         uint32_t c1 = std::log2(gray_code[1 << i] ^ gray_code[(1u << (i + 1)) - 1u]);
-        circuit.apply_operator(Op::X(), {qubits[c1], qubits[i]});
+        circuit.apply_operator(Op::X(), {qubits[c1], qubits[i]}, cbits);
 
         qubits_states[i] ^= qubits_states[c1];
         auto angle = parities.extract_term(qubits_states[i]);
         if (angle != 0.0) {
-            circuit.apply_operator(Op::P(angle), {qubits[i]});
+            circuit.apply_operator(Op::P(angle), {qubits[i]}, cbits);
         }
     }
 }
 
 }
 
-void all_linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits, LinearPP const& parities)
+void all_linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
+    std::vector<Cbit> const& cbits, LinearPP const& parities)
 {
     if (parities.size() == 0) {
         return;
     }
-    synthesize(circuit, qubits, parities);
+    synthesize(circuit, qubits, cbits, parities);
 }
 
 Circuit all_linear_synth(uint32_t num_qubits, LinearPP const& parities)
 {
     Circuit circuit;
-
-    // Create the necessary qubits
-    std::vector<Qubit> wires;
-    wires.reserve(num_qubits);
+    std::vector<Qubit> qubits;
+    qubits.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
-        wires.emplace_back(circuit.create_qubit());
+        qubits.emplace_back(circuit.create_qubit());
     }
-    all_linear_synth(circuit, wires, parities);
+    all_linear_synth(circuit, qubits, {}, parities);
     return circuit;
 }
 

--- a/lib/Passes/Synthesis/all_linear_synth.cpp
+++ b/lib/Passes/Synthesis/all_linear_synth.cpp
@@ -11,7 +11,7 @@ namespace {
 
 // I added this level of indirection because I can implement this method with
 // other codes or just using binary sequence.
-inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits, LinearPP parities)
+inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits, LinearPP parities)
 {
     // Generate Gray code
     std::vector<uint32_t> gray_code(1u << circuit.num_qubits());
@@ -55,7 +55,7 @@ inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits, Lin
 
 }
 
-void all_linear_synth(Circuit& circuit, std::vector<WireRef> const& qubits, LinearPP const& parities)
+void all_linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits, LinearPP const& parities)
 {
     if (parities.size() == 0) {
         return;
@@ -68,7 +68,7 @@ Circuit all_linear_synth(uint32_t num_qubits, LinearPP const& parities)
     Circuit circuit;
 
     // Create the necessary qubits
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Passes/Synthesis/decomp_synth.cpp
+++ b/lib/Passes/Synthesis/decomp_synth.cpp
@@ -81,12 +81,12 @@ inline auto decompose(std::vector<uint32_t>& perm, uint32_t var)
     return std::make_pair(std::move(left), std::move(right));
 }
 
-inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
+inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
     std::vector<uint32_t> perm)
 {
     std::vector<kitty::dynamic_truth_table> truth_tables;
     truth_tables.reserve(qubits.size() * 2);
-    std::list<std::pair<uint32_t, std::vector<WireRef>>> gates;
+    std::list<std::pair<uint32_t, std::vector<Qubit>>> gates;
     auto pos = gates.begin();
     for (uint32_t i = 0u; i < qubits.size(); ++i) {
         auto&& [left, right] = decompose(perm, i);
@@ -103,7 +103,7 @@ inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
         }
 
         if (!kitty::is_const0(left_tt)) {
-            std::vector<WireRef> left_qubits;
+            std::vector<Qubit> left_qubits;
             for (auto element : kitty::min_base_inplace(left_tt)) {
                 left_qubits.emplace_back(qubits.at(element));
             }
@@ -114,7 +114,7 @@ inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
             ++pos;
         }
         if (!kitty::is_const0(right_tt)) {
-            std::vector<WireRef> right_qubits;
+            std::vector<Qubit> right_qubits;
             for (auto element : kitty::min_base_inplace(right_tt)) {
                 right_qubits.emplace_back(qubits.at(element));
             }
@@ -131,7 +131,7 @@ inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
 
 }
 
-void decomp_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void decomp_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     std::vector<uint32_t> const& perm)
 {
     assert(!perm.empty() && !(perm.size() & (perm.size() - 1)));
@@ -145,7 +145,7 @@ Circuit decomp_synth(std::vector<uint32_t> const& perm)
 
     // Create the necessary qubits
     uint32_t const num_qubits = __builtin_ctz(perm.size());
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Passes/Synthesis/decomp_synth.cpp
+++ b/lib/Passes/Synthesis/decomp_synth.cpp
@@ -82,7 +82,7 @@ inline auto decompose(std::vector<uint32_t>& perm, uint32_t var)
 }
 
 inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
-    std::vector<uint32_t> perm)
+    std::vector<Cbit> const& cbits, std::vector<uint32_t> perm)
 {
     std::vector<kitty::dynamic_truth_table> truth_tables;
     truth_tables.reserve(qubits.size() * 2);
@@ -90,7 +90,6 @@ inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
     auto pos = gates.begin();
     for (uint32_t i = 0u; i < qubits.size(); ++i) {
         auto&& [left, right] = decompose(perm, i);
-
         auto& left_tt = truth_tables.emplace_back(qubits.size());
         auto& right_tt = truth_tables.emplace_back(qubits.size());
         for (uint32_t row = 0; row < perm.size(); ++row) {
@@ -125,32 +124,31 @@ inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
         }
     }
     for (auto const& [tt_idx, qubits] : gates) {
-        circuit.apply_operator(Op::TruthTable(truth_tables.at(tt_idx)), qubits);
+        circuit.apply_operator(Op::TruthTable(truth_tables.at(tt_idx)), qubits,
+            cbits);
     }
 }
 
 }
 
-void decomp_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    std::vector<uint32_t> const& perm)
+void decomp_synth(Circuit& circuit, std::vector<Qubit> const& qubits, 
+    std::vector<Cbit> const& cbits, std::vector<uint32_t> const& perm)
 {
     assert(!perm.empty() && !(perm.size() & (perm.size() - 1)));
-    synthesize(circuit, qubits, perm);
+    synthesize(circuit, qubits, cbits, perm);
 }
 
 Circuit decomp_synth(std::vector<uint32_t> const& perm)
 {
     assert(!perm.empty() && !(perm.size() & (perm.size() - 1)));
     Circuit circuit;
-
-    // Create the necessary qubits
     uint32_t const num_qubits = __builtin_ctz(perm.size());
-    std::vector<Qubit> wires;
-    wires.reserve(num_qubits);
+    std::vector<Qubit> qubits;
+    qubits.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
-        wires.emplace_back(circuit.create_qubit());
+        qubits.emplace_back(circuit.create_qubit());
     }
-    decomp_synth(circuit, wires, perm);
+    decomp_synth(circuit, qubits, {}, perm);
     return circuit;
 }
 

--- a/lib/Passes/Synthesis/diagonal_synth.cpp
+++ b/lib/Passes/Synthesis/diagonal_synth.cpp
@@ -26,7 +26,7 @@ inline void complement_qubit(uint32_t i, std::vector<Angle>& angles)
 }
 
 inline std::vector<Angle> fix_angles(
-    std::vector<WireRef>& qubits, std::vector<Angle> const& angles)
+    std::vector<Qubit>& qubits, std::vector<Angle> const& angles)
 {
     std::vector<Angle> new_angles;
     std::transform(angles.begin(), angles.end(),
@@ -37,11 +37,11 @@ inline std::vector<Angle> fix_angles(
     // Normalize qubits polarity
     uint32_t index = 0u;
     for (uint32_t i = qubits.size(); i-- > 0;) {
-        if (!qubits.at(index).is_complemented()) {
+        if (qubits.at(index).polarity() != Qubit::Polarity::negative) {
             index += 1;
             continue;
         }
-        qubits.at(index).complement();
+        qubits.at(index) = !qubits.at(index);
         complement_qubit(index, new_angles);
         index += 1;
     }
@@ -64,7 +64,7 @@ inline void fast_hadamard_transform(std::vector<Angle>& angles)
 
 }
 
-void diagonal_synth(Circuit& circuit, std::vector<WireRef> qubits,
+void diagonal_synth(Circuit& circuit, std::vector<Qubit> qubits,
     std::vector<Angle> const& angles, nlohmann::json const& config)
 {
     // Number of angles + 1 needs to be a power of two!
@@ -99,7 +99,7 @@ Circuit diagonal_synth(std::vector<Angle> const& angles, nlohmann::json const& c
 
     Circuit circuit;
     // Create the necessary qubits
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Passes/Synthesis/gray_synth.cpp
+++ b/lib/Passes/Synthesis/gray_synth.cpp
@@ -116,21 +116,9 @@ inline GateList synthesize(std::vector<Qubit> const& qubits, BMatrix& matrix)
 }
 }
 
-/*! \brief Synthesis of a CNOT-dihedral circuits with all linear combinations.
- *
- * This is the in-place variant of ``all_linear_synth`` in which the circuit is
- * passed as a parameter and can potentially already contain some gates.  The
- * parameter ``qubits`` provides a qubit mapping to the existing qubits in the
- * circuit.
- *
- * \param[inout] circuit A circuit in which the parities will be synthesized on.
- * \param[in] qubits The qubits that will be used.
- * \param[in] linear_trans The overall linear transformation
- * \param[in] parities List of parities and their associated angles.
- */
-// Each column is a parity, num_rows = num_qubits
-void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    BMatrix linear_trans, LinearPP parities, nlohmann::json const& config)
+void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits, 
+    std::vector<Cbit> const& cbits, BMatrix linear_trans, LinearPP parities,
+    nlohmann::json const& config)
 {
     if (parities.size() == 0) {
         return;
@@ -153,17 +141,18 @@ void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
         qubits_states.at(i) = (1u << i);
         auto angle = parities.extract_term(qubits_states.at(i));
         if (angle != 0.0) {
-            circuit.apply_operator(Op::P(angle), {qubits.at(i)});
+            circuit.apply_operator(Op::P(angle), {qubits.at(i)}, cbits);
         }
     }
     // Effectively create the circuit
     for (auto const& [control, target] : gates) {
-        circuit.apply_operator(Op::X(), {qubits.at(control), qubits.at(target)});
+        circuit.apply_operator(Op::X(), {qubits.at(control), qubits.at(target)},
+            cbits);
         qubits_states.at(target) ^= qubits_states.at(control);
         linear_trans.row(target) += linear_trans.row(control);
         auto angle = parities.extract_term(qubits_states.at(target));
         if (angle != 0.0) {
-            circuit.apply_operator(Op::P(angle), {qubits.at(target)});
+            circuit.apply_operator(Op::P(angle), {qubits.at(target)}, cbits);
         }
     }
 
@@ -173,30 +162,20 @@ void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
         linear_synth_cfg["linear_synth"] = config["linear_synth"];
     }
     linear_synth_cfg["linear_synth"]["inverse"] = true;
-    linear_synth(circuit, qubits, linear_trans, linear_synth_cfg);
+    linear_synth(circuit, qubits, cbits, linear_trans, linear_synth_cfg);
 }
 
-/*! \brief Synthesis of a CNOT-dihedral circuits.
- *
- * \param[in] num_qubits The number of qubits.
- * \param[in] parities List of parities and their associated angles.
- * \return A CNOT-dihedral circuit on `num_qubits`.
- */
 Circuit gray_synth(uint32_t num_qubits, LinearPP const& parities,
     nlohmann::json const& config)
 {
     Circuit circuit;
-
-    // Create the necessary qubits
-    std::vector<Qubit> wires;
-    wires.reserve(num_qubits);
+    std::vector<Qubit> qubits;
+    qubits.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
-        wires.emplace_back(circuit.create_qubit());
+        qubits.emplace_back(circuit.create_qubit());
     }
-
-    // Create the linear
     BMatrix linear_trans = BMatrix::Identity(num_qubits, num_qubits);
-    gray_synth(circuit, wires, linear_trans, parities, config);
+    gray_synth(circuit, qubits, {}, linear_trans, parities, config);
     return circuit;
 }
 

--- a/lib/Passes/Synthesis/gray_synth.cpp
+++ b/lib/Passes/Synthesis/gray_synth.cpp
@@ -62,7 +62,7 @@ inline void add_gate(State const& state, BMatrix& matrix, GateList& gates)
     }
 }
 
-inline GateList synthesize(std::vector<WireRef> const& qubits, BMatrix& matrix)
+inline GateList synthesize(std::vector<Qubit> const& qubits, BMatrix& matrix)
 {
     GateList gates;
     uint32_t const num_qubits = qubits.size();
@@ -129,7 +129,7 @@ inline GateList synthesize(std::vector<WireRef> const& qubits, BMatrix& matrix)
  * \param[in] parities List of parities and their associated angles.
  */
 // Each column is a parity, num_rows = num_qubits
-void gray_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void gray_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     BMatrix linear_trans, LinearPP parities, nlohmann::json const& config)
 {
     if (parities.size() == 0) {
@@ -188,7 +188,7 @@ Circuit gray_synth(uint32_t num_qubits, LinearPP const& parities,
     Circuit circuit;
 
     // Create the necessary qubits
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Passes/Synthesis/linear_synth.cpp
+++ b/lib/Passes/Synthesis/linear_synth.cpp
@@ -94,7 +94,7 @@ inline GateList lower_cnot_synthesis(BMatrix& matrix, uint32_t section_size)
     return gates;
 }
 
-inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
+inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
     BMatrix matrix, uint32_t const section_size, bool const inverse)
 {
     GateList lower = lower_cnot_synthesis(matrix, section_size);
@@ -122,7 +122,7 @@ inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
     }
 }
 
-inline void best_effort_synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
+inline void best_effort_synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
     BMatrix const& matrix, bool const reverse)
 {
     BMatrix temp_matrix = matrix;
@@ -156,7 +156,7 @@ inline void best_effort_synthesize(Circuit& circuit, std::vector<WireRef> const&
 }
 }
 
-void linear_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     BMatrix const& matrix, nlohmann::json const& config)
 {
     Config cfg(config);
@@ -174,7 +174,7 @@ Circuit linear_synth(BMatrix const& matrix, nlohmann::json const& config)
 
     // Create the necessary qubits
     uint32_t const num_qubits = matrix.rows();
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Passes/Synthesis/pkrm_synth.cpp
+++ b/lib/Passes/Synthesis/pkrm_synth.cpp
@@ -32,35 +32,36 @@ struct Config {
 };
 
 inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
-    kitty::dynamic_truth_table const& function, Config const& config)
+    std::vector<Cbit> const& cbits, kitty::dynamic_truth_table const& function,
+    Config const& config)
 {
     Qubit const target = qubits.back();
     for (auto const& cube : kitty::esop_from_optimum_pkrm(function)) {
         uint32_t bits = cube._bits;
         uint32_t mask = cube._mask;
-        std::vector<Qubit> wires;
+        std::vector<Qubit> qs;
         for (uint32_t v = 0u; mask; mask >>= 1, bits >>= 1, ++v) {
             if ((mask & 1) == 0u) {
                 continue;
             }
-            wires.push_back((bits & 1) ? qubits.at(v) : !qubits.at(v));
+            qs.push_back((bits & 1) ? qubits.at(v) : !qubits.at(v));
         }
         if (config.phase_esop) {
-            auto it = std::find_if(wires.rbegin(), wires.rend(), 
-            [](Qubit ref) {
-                return ref.polarity() == Qubit::Polarity::positive;
+            auto it = std::find_if(qs.rbegin(), qs.rend(), 
+            [](Qubit qubit) {
+                return qubit.polarity() == Qubit::Polarity::positive;
             });
-            if (it == wires.rend()) {
-                circuit.apply_operator(Op::X(), {wires.back()});
-                circuit.apply_operator(Op::Z(), wires);
-                circuit.apply_operator(Op::X(), {wires.back()});
+            if (it == qs.rend()) {
+                circuit.apply_operator(Op::X(), {qs.back()}, cbits);
+                circuit.apply_operator(Op::Z(), qs, cbits);
+                circuit.apply_operator(Op::X(), {qs.back()}, cbits);
             } else {
-                std::swap(*it, wires.back());
-                circuit.apply_operator(Op::Z(), wires);
+                std::swap(*it, qs.back());
+                circuit.apply_operator(Op::Z(), qs, cbits);
             }
         } else {
-            wires.push_back(target);
-            circuit.apply_operator(Op::X(), wires);
+            qs.push_back(target);
+            circuit.apply_operator(Op::X(), qs, cbits);
         }
     }
 }
@@ -68,59 +69,60 @@ inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
 }
 
 void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    kitty::dynamic_truth_table const& function, nlohmann::json const& config)
+     std::vector<Cbit> const& cbits, kitty::dynamic_truth_table const& function,
+     nlohmann::json const& config)
 {
     Config cfg(config);
     assert(cfg.phase_esop ? qubits.size() == function.num_vars()
                           : qubits.size() == (function.num_vars() + 1));
-    synthesize(circuit, qubits, function, cfg);
+    synthesize(circuit, qubits, cbits, function, cfg);
 }
 
-Circuit pkrm_synth(kitty::dynamic_truth_table const& function, nlohmann::json const& config)
+Circuit pkrm_synth(kitty::dynamic_truth_table const& function,
+    nlohmann::json const& config)
 {
     Circuit circuit;
     Config cfg(config);
-
-    std::vector<Qubit> wires;
-    wires.reserve(function.num_vars() + 1);
+    std::vector<Qubit> qubits;
+    qubits.reserve(function.num_vars() + 1);
     for (uint32_t i = 0u; i < function.num_vars(); ++i) {
-        wires.emplace_back(circuit.create_qubit());
+        qubits.emplace_back(circuit.create_qubit());
     }
     if (!cfg.phase_esop) {
-        wires.emplace_back(circuit.create_qubit());
+        qubits.emplace_back(circuit.create_qubit());
     }
-    synthesize(circuit, wires, function, cfg);
+    synthesize(circuit, qubits, {}, function, cfg);
     return circuit;
 }
 
-void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    Instruction const& inst, nlohmann::json const& config)
-{
-    if (!inst.is_a<Op::TruthTable>()) {
-        return;
-    }
-    auto tt = inst.cast<Op::TruthTable>();
-    pkrm_synth(circuit, qubits, tt.truth_table(), config);
-}
+// void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
+//     Instruction const& inst, nlohmann::json const& config)
+// {
+//     if (!inst.is_a<Op::TruthTable>()) {
+//         return;
+//     }
+//     auto tt = inst.cast<Op::TruthTable>();
+//     pkrm_synth(circuit, qubits, inst.cbits(), tt.truth_table(), config);
+// }
 
-void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    mockturtle::xag_network const& xag, nlohmann::json const& config)
-{
-    if (xag.num_pis() <= 16u && xag.num_pos() == 1) {
-        auto tts = xag_simulate(xag);
-        pkrm_synth(circuit, qubits, tts.at(0), config);
-        return;
-    }
-}
+// void pkrm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
+//     mockturtle::xag_network const& xag, nlohmann::json const& config)
+// {
+//     if (xag.num_pis() <= 16u && xag.num_pos() == 1) {
+//         auto tts = xag_simulate(xag);
+//         pkrm_synth(circuit, qubits, tts.at(0), config);
+//         return;
+//     }
+// }
 
-Circuit pkrm_synth(mockturtle::xag_network const& xag, nlohmann::json const& config)
-{
-    if (xag.num_pis() <= 16u && xag.num_pos() == 1) {
-        auto tts = xag_simulate(xag);
-        return pkrm_synth(tts.at(0), config);
-    }
-    Circuit circuit;
-    return circuit;
-}
+// Circuit pkrm_synth(mockturtle::xag_network const& xag, nlohmann::json const& config)
+// {
+//     if (xag.num_pis() <= 16u && xag.num_pos() == 1) {
+//         auto tts = xag_simulate(xag);
+//         return pkrm_synth(tts.at(0), config);
+//     }
+//     Circuit circuit;
+//     return circuit;
+// }
 
 } // namespace tweedledum

--- a/lib/Passes/Synthesis/pprm_synth.cpp
+++ b/lib/Passes/Synthesis/pprm_synth.cpp
@@ -26,12 +26,12 @@ struct Config {
     }
 };
 
-inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
+inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
     kitty::dynamic_truth_table const& function, Config config)
 {
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(qubits.size());
-    WireRef const target = qubits.back();
+    Qubit const target = qubits.back();
     for (auto const& cube : kitty::esop_from_pprm(function)) {
         auto bits = cube._bits;
         for (uint32_t v = 0u; bits; bits >>= 1, ++v) {
@@ -52,7 +52,7 @@ inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
 
 }
 
-void pprm_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void pprm_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     kitty::dynamic_truth_table const& function, nlohmann::json const& config)
 {
     Config cfg(config);
@@ -66,7 +66,7 @@ Circuit pprm_synth(kitty::dynamic_truth_table const& function, nlohmann::json co
     Circuit circuit;
     Config cfg(config);
 
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(function.num_vars() + 1);
     for (uint32_t i = 0u; i < function.num_vars(); ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Passes/Synthesis/spectrum_synth.cpp
+++ b/lib/Passes/Synthesis/spectrum_synth.cpp
@@ -11,7 +11,7 @@
 
 namespace tweedledum {
 
-void spectrum_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void spectrum_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     kitty::dynamic_truth_table const& function, nlohmann::json const& config)
 {
     uint32_t const num_controls = function.num_vars();
@@ -44,7 +44,7 @@ Circuit spectrum_synth(kitty::dynamic_truth_table const& function, nlohmann::jso
 {
     Circuit circuit;
     // Create the necessary qubits
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(function.num_vars() + 1);
     for (uint32_t i = 0u; i < function.num_vars() + 1; ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Passes/Synthesis/spectrum_synth.cpp
+++ b/lib/Passes/Synthesis/spectrum_synth.cpp
@@ -12,7 +12,8 @@
 namespace tweedledum {
 
 void spectrum_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    kitty::dynamic_truth_table const& function, nlohmann::json const& config)
+    std::vector<Cbit> const& cbits, kitty::dynamic_truth_table const& function,
+    nlohmann::json const& config)
 {
     uint32_t const num_controls = function.num_vars();
     assert(qubits.size() >= (num_controls + 1u));
@@ -31,25 +32,26 @@ void spectrum_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
         }
         parities.add_term(i, norm * spectrum[i]);
     }
-    circuit.apply_operator(Op::H(), {qubits.back()});
+    circuit.apply_operator(Op::H(), {qubits.back()}, cbits);
     if (parities.size() == spectrum.size() - 1) {
-        all_linear_synth(circuit, qubits, parities);
+        all_linear_synth(circuit, qubits, cbits, parities);
     } else {
-        gray_synth(circuit, qubits, BMatrix::Identity(qubits.size(), qubits.size()), parities, config);
+        gray_synth(circuit, qubits, cbits, 
+            BMatrix::Identity(qubits.size(), qubits.size()), parities, config);
     }
-    circuit.apply_operator(Op::H(), {qubits.back()});
+    circuit.apply_operator(Op::H(), {qubits.back()}, cbits);
 }
 
-Circuit spectrum_synth(kitty::dynamic_truth_table const& function, nlohmann::json const& config)
+Circuit spectrum_synth(kitty::dynamic_truth_table const& function,
+    nlohmann::json const& config)
 {
     Circuit circuit;
-    // Create the necessary qubits
-    std::vector<Qubit> wires;
-    wires.reserve(function.num_vars() + 1);
+    std::vector<Qubit> qubits;
+    qubits.reserve(function.num_vars() + 1);
     for (uint32_t i = 0u; i < function.num_vars() + 1; ++i) {
-        wires.emplace_back(circuit.create_qubit());
+        qubits.emplace_back(circuit.create_qubit());
     }
-    spectrum_synth(circuit, wires, function, config);
+    spectrum_synth(circuit, qubits, {}, function, config);
     return circuit;
 }
 

--- a/lib/Passes/Synthesis/transform_synth.cpp
+++ b/lib/Passes/Synthesis/transform_synth.cpp
@@ -163,14 +163,14 @@ inline GateList multidirectional(std::vector<uint32_t> perm)
     return gates;
 }
 
-inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
+inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
     std::vector<uint32_t> const& perm)
 {
     // GateList gates = unidirectional(perm);
     // GateList gates = bidirectional(perm);
     GateList gates = multidirectional(perm);
     for (auto [controls, targets] : gates) {
-        std::vector<WireRef> cs;
+        std::vector<Qubit> cs;
         for (uint32_t c = 0; controls; controls >>= 1, ++c) {
             if (controls & 1) {
                 cs.emplace_back(qubits.at(c));
@@ -189,7 +189,7 @@ inline void synthesize(Circuit& circuit, std::vector<WireRef> const& qubits,
 }
 }
 
-void transform_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void transform_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     std::vector<uint32_t> const& perm)
 {
     assert(!perm.empty() && !(perm.size() & (perm.size() - 1)));
@@ -203,7 +203,7 @@ Circuit transform_synth(std::vector<uint32_t> const& perm)
 
     // Create the necessary qubits
     uint32_t const num_qubits = __builtin_ctz(perm.size());
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Passes/Synthesis/transform_synth.cpp
+++ b/lib/Passes/Synthesis/transform_synth.cpp
@@ -164,7 +164,7 @@ inline GateList multidirectional(std::vector<uint32_t> perm)
 }
 
 inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
-    std::vector<uint32_t> const& perm)
+    std::vector<Cbit> const& cbits, std::vector<uint32_t> const& perm)
 {
     // GateList gates = unidirectional(perm);
     // GateList gates = bidirectional(perm);
@@ -182,7 +182,7 @@ inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
             }
             // FIXME: Quite hacky
             cs.push_back(qubits.at(t));
-            circuit.apply_operator(Op::X(), {cs});
+            circuit.apply_operator(Op::X(), {cs}, cbits);
             cs.pop_back();
         }
     }
@@ -190,25 +190,23 @@ inline void synthesize(Circuit& circuit, std::vector<Qubit> const& qubits,
 }
 
 void transform_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
-    std::vector<uint32_t> const& perm)
+    std::vector<Cbit> const& cbits, std::vector<uint32_t> const& perm)
 {
     assert(!perm.empty() && !(perm.size() & (perm.size() - 1)));
-    synthesize(circuit, qubits, perm);
+    synthesize(circuit, qubits, cbits, perm);
 }
 
 Circuit transform_synth(std::vector<uint32_t> const& perm)
 {
     assert(!perm.empty() && !(perm.size() & (perm.size() - 1)));
     Circuit circuit;
-
-    // Create the necessary qubits
     uint32_t const num_qubits = __builtin_ctz(perm.size());
-    std::vector<Qubit> wires;
-    wires.reserve(num_qubits);
+    std::vector<Qubit> qubits;
+    qubits.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
-        wires.emplace_back(circuit.create_qubit());
+        qubits.emplace_back(circuit.create_qubit());
     }
-    transform_synth(circuit, wires, perm);
+    transform_synth(circuit, qubits, {}, perm);
     return circuit;
 }
 

--- a/lib/Passes/Synthesis/xag/xag_synth.cpp
+++ b/lib/Passes/Synthesis/xag/xag_synth.cpp
@@ -29,7 +29,7 @@ public:
     Synthesizer() = default;
 
     void operator()(mockturtle::xag_network const& xag, Circuit& circuit,
-        std::vector<WireRef> const& qubits);
+        std::vector<Qubit> const& qubits);
 
 private:
     void pre_process(HighLevelXAG& hl_xag);
@@ -38,15 +38,15 @@ private:
     
     void cleanup(Circuit& circuit, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref);
 
-    WireRef request_ancilla(Circuit& circuit, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref);
-    void release_ancilla(Circuit& circuit, WireRef qubit);
-    void add_parity(Circuit& circuit, std::vector<WireRef> const& qubits);
-    void compute_node(Circuit& circuit, WireRef target, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref);
-    void cleanup_node(Circuit& circuit, WireRef target, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref);
+    Qubit request_ancilla(Circuit& circuit, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref);
+    void release_ancilla(Circuit& circuit, Qubit qubit);
+    void add_parity(Circuit& circuit, std::vector<Qubit> const& qubits);
+    void compute_node(Circuit& circuit, Qubit target, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref);
+    void cleanup_node(Circuit& circuit, Qubit target, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref);
 
-    std::vector<WireRef> qubits_;
-    // NodeRef -> WireRef, tells in which qubit a node was computed
-    std::vector<WireRef> to_qubit_;
+    std::vector<Qubit> qubits_;
+    // NodeRef -> Qubit, tells in which qubit a node was computed
+    std::vector<Qubit> to_qubit_;
     // NodeRef -> Cleanup method
     std::vector<uint8_t> cleanup_;
 
@@ -86,7 +86,7 @@ void Synthesizer::pre_process(HighLevelXAG& hl_xag)
         HighLevelXAG::NodeRef const node_ref = ref.first;
         // The same gate might drive different outputs.  Here I check if
         // this gate was already assigned a qubit.  If yes, do nothing
-        if (to_qubit_.at(node_ref) != WireRef::invalid()) {
+        if (to_qubit_.at(node_ref) != Qubit::invalid()) {
             qubit_idx += 1;
             return;
         }
@@ -121,7 +121,7 @@ void Synthesizer::pre_process(HighLevelXAG& hl_xag)
         HighLevelXAG::NodeRef const node_ref = ref.first;
         // The same gate might drive different outputs.  Here I check if
         // this gate was already assigned a qubit.  If yes, do nothing
-        if (to_qubit_.at(node_ref) != WireRef::invalid()) {
+        if (to_qubit_.at(node_ref) != Qubit::invalid()) {
             qubit_idx += 1;
             return;
         }
@@ -138,7 +138,7 @@ void Synthesizer::pre_process(HighLevelXAG& hl_xag)
         
         for (HighLevelXAG::NodeRef const input_ref : node) {
             HighLevelXAG::Node const& input = hl_xag.get_node(input_ref);
-            if (to_qubit_.at(input_ref) != WireRef::invalid()) {
+            if (to_qubit_.at(input_ref) != Qubit::invalid()) {
                 if (!input.is_input()) {
                     only_inputs = false;
                 }
@@ -186,7 +186,7 @@ void Synthesizer::pre_process(HighLevelXAG& hl_xag)
     });
 }
 
-WireRef Synthesizer::request_ancilla(Circuit& circuit, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref)
+Qubit Synthesizer::request_ancilla(Circuit& circuit, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref)
 {
     // HighLevelXAG::Node const& node = hl_xag.get_node(ref);
     // for (uint32_t i = hl_xag.num_inputs(); i < qubits_.size(); ++i) {
@@ -204,7 +204,7 @@ WireRef Synthesizer::request_ancilla(Circuit& circuit, HighLevelXAG& hl_xag, Hig
     return circuit.request_ancilla();
 }
 
-void Synthesizer::release_ancilla(Circuit& circuit, WireRef qubit)
+void Synthesizer::release_ancilla(Circuit& circuit, Qubit qubit)
 {
     auto it = std::find(qubits_.crbegin(), qubits_.crend(), qubit);
     if (it != qubits_.crend()) {
@@ -213,7 +213,7 @@ void Synthesizer::release_ancilla(Circuit& circuit, WireRef qubit)
     circuit.release_ancilla(qubit);
 }
 
-void Synthesizer::add_parity(Circuit& circuit, std::vector<WireRef> const& qubits)
+void Synthesizer::add_parity(Circuit& circuit, std::vector<Qubit> const& qubits)
 {
     if (qubits.size() == 1) {
         return;
@@ -221,12 +221,12 @@ void Synthesizer::add_parity(Circuit& circuit, std::vector<WireRef> const& qubit
     circuit.apply_operator(Op::Parity(), qubits);
 }
 
-void Synthesizer::compute_node(Circuit& circuit, WireRef target, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref)
+void Synthesizer::compute_node(Circuit& circuit, Qubit target, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref)
 {
     HighLevelXAG::Node const& node = hl_xag.get_node(ref);
-    std::vector<WireRef> in0;
-    std::vector<WireRef> in1;
-    std::vector<WireRef> in01;
+    std::vector<Qubit> in0;
+    std::vector<Qubit> in1;
+    std::vector<Qubit> in01;
 
     // fmt::print(">>>>>>>> input\n");
     std::for_each(node.cbegin_in0(), node.cend_in0(),
@@ -236,7 +236,7 @@ void Synthesizer::compute_node(Circuit& circuit, WireRef target, HighLevelXAG& h
         }
         in0.push_back(to_qubit_.at(input_ref));
         hl_xag.dereference(input_ref);
-        assert(to_qubit_.at(input_ref) != WireRef::invalid());
+        assert(to_qubit_.at(input_ref) != Qubit::invalid());
     });
 
     if (node.is_parity()) {
@@ -249,14 +249,14 @@ void Synthesizer::compute_node(Circuit& circuit, WireRef target, HighLevelXAG& h
     [&](HighLevelXAG::NodeRef input_ref) {
         in1.push_back(to_qubit_.at(input_ref)); 
         hl_xag.dereference(input_ref);
-        assert(to_qubit_.at(input_ref) != WireRef::invalid());
+        assert(to_qubit_.at(input_ref) != Qubit::invalid());
     });
 
     std::for_each(node.cbegin_in01(), node.cend_in01(),
     [&](HighLevelXAG::NodeRef input_ref) {
         in01.push_back(to_qubit_.at(input_ref));
         hl_xag.dereference(input_ref);
-        assert(to_qubit_.at(input_ref) != WireRef::invalid());
+        assert(to_qubit_.at(input_ref) != Qubit::invalid());
     });
     // fmt::print(">>>>>>>> actual: {}, {}, {}\n", in0.size(), in1.size(), in01.size());
 
@@ -270,8 +270,8 @@ void Synthesizer::compute_node(Circuit& circuit, WireRef target, HighLevelXAG& h
     add_parity(circuit, in1);
     // fmt::print(">>>>>>>> Tof\n");
     // Compute Toffoli
-    WireRef c0 = node.is_negated(0) ? !in0.back() : in0.back();
-    WireRef c1 = node.is_negated(1) ? !in1.back() : in1.back();
+    Qubit c0 = node.is_negated(0) ? !in0.back() : in0.back();
+    Qubit c1 = node.is_negated(1) ? !in1.back() : in1.back();
     circuit.apply_operator(Op::X(), {c0, c1, target});
     // fmt::print(">>>>>>>> C\n");
     // Cleanup the input to the Toffoli gate
@@ -283,32 +283,32 @@ void Synthesizer::compute_node(Circuit& circuit, WireRef target, HighLevelXAG& h
     add_parity(circuit, in0);
 }
 
-void Synthesizer::cleanup_node(Circuit& circuit, WireRef target, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref)
+void Synthesizer::cleanup_node(Circuit& circuit, Qubit target, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref)
 {
     HighLevelXAG::Node const& node = hl_xag.get_node(ref);
-    std::vector<WireRef> in0;
-    std::vector<WireRef> in1;
-    std::vector<WireRef> in01;
+    std::vector<Qubit> in0;
+    std::vector<Qubit> in1;
+    std::vector<Qubit> in01;
 
     std::for_each(node.cbegin_in0(), node.cend_in0(),
     [&](HighLevelXAG::NodeRef input_ref) { 
         in0.push_back(to_qubit_.at(input_ref));
         hl_xag.dereference(input_ref);
-        assert(to_qubit_.at(input_ref) != WireRef::invalid());
+        assert(to_qubit_.at(input_ref) != Qubit::invalid());
     });
 
     std::for_each(node.cbegin_in1(), node.cend_in1(),
     [&](HighLevelXAG::NodeRef input_ref) {
         in1.push_back(to_qubit_.at(input_ref)); 
         hl_xag.dereference(input_ref);
-        assert(to_qubit_.at(input_ref) != WireRef::invalid());
+        assert(to_qubit_.at(input_ref) != Qubit::invalid());
     });
 
     std::for_each(node.cbegin_in01(), node.cend_in01(),
     [&](HighLevelXAG::NodeRef input_ref) {
         in01.push_back(to_qubit_.at(input_ref));
         hl_xag.dereference(input_ref);
-        assert(to_qubit_.at(input_ref) != WireRef::invalid());
+        assert(to_qubit_.at(input_ref) != Qubit::invalid());
     });
 
     // Compute the inputs to the Toffoli gate (inplace)
@@ -320,8 +320,8 @@ void Synthesizer::cleanup_node(Circuit& circuit, WireRef target, HighLevelXAG& h
     }
     add_parity(circuit, in1);
     // Compute Toffoli
-    WireRef c0 = node.is_negated(0) ? !in0.back() : in0.back();
-    WireRef c1 = node.is_negated(1) ? !in1.back() : in1.back();
+    Qubit c0 = node.is_negated(0) ? !in0.back() : in0.back();
+    Qubit c1 = node.is_negated(1) ? !in1.back() : in1.back();
     // circuit.create_instruction(GateLib::R1(0.0), {c0}, c1);
     // circuit.create_instruction(GateLib::H(), {target});
     // Cleanup the input to the Toffoli gate
@@ -336,8 +336,8 @@ void Synthesizer::cleanup_node(Circuit& circuit, WireRef target, HighLevelXAG& h
 bool Synthesizer::try_compute(
     Circuit& circuit, HighLevelXAG& hl_xag, HighLevelXAG::NodeRef ref)
 {
-    WireRef& qubit = to_qubit_.at(ref);
-    if (qubit == WireRef::invalid()) {
+    Qubit& qubit = to_qubit_.at(ref);
+    if (qubit == Qubit::invalid()) {
         qubit = request_ancilla(circuit, hl_xag, ref);
     } else {
         auto it = std::find(qubits_.cbegin(), qubits_.cend(), qubit);
@@ -350,7 +350,7 @@ bool Synthesizer::try_compute(
         }
         qubit_info_.at(idx).last_node = ref;
     }
-    assert(qubit != WireRef::invalid());
+    assert(qubit != Qubit::invalid());
     // fmt::print(">>>>>> compute\n");
     compute_node(circuit, qubit, hl_xag, ref);
     // fmt::print(">>>>>> done\n");
@@ -364,7 +364,7 @@ void Synthesizer::cleanup(
     // cleanup_node(circuit, to_qubit_.at(ref), hl_xag, ref);
     compute_node(circuit, to_qubit_.at(ref), hl_xag, ref);
     release_ancilla(circuit, to_qubit_.at(ref));
-    to_qubit_.at(ref) = WireRef::invalid();
+    to_qubit_.at(ref) = Qubit::invalid();
     cleanup_.at(ref) = 0;
 }
 
@@ -386,11 +386,11 @@ void Synthesizer::try_cleanup_inputs(Circuit& circuit, HighLevelXAG& hl_xag, Hig
 }
 
 void Synthesizer::operator()(mockturtle::xag_network const& xag,
-    Circuit& circuit, std::vector<WireRef> const& qubits)
+    Circuit& circuit, std::vector<Qubit> const& qubits)
 {
     HighLevelXAG hl_xag = to_pag(xag);
     qubits_ = qubits;
-    to_qubit_.resize(hl_xag.size(), WireRef::invalid());
+    to_qubit_.resize(hl_xag.size(), Qubit::invalid());
     qubit_info_.resize(qubits.size(), {0, hl_xag.num_levels()});
     cleanup_.resize(hl_xag.size(), 1); // by default cleanup everything (:
 
@@ -462,7 +462,7 @@ void Synthesizer::operator()(mockturtle::xag_network const& xag,
 } // namespace xag_synth_detail
 #pragma endregion
 
-void xag_synth(Circuit& circuit, std::vector<WireRef> const& qubits,
+void xag_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
     mockturtle::xag_network const& xag, nlohmann::json const& config)
 {
     xag_synth_detail::Synthesizer xag_synthesize;
@@ -475,7 +475,7 @@ Circuit xag_synth(mockturtle::xag_network const& xag, nlohmann::json const& conf
     // Config cfg(config);
     // Create the necessary qubits
     uint32_t num_qubits = xag.num_pis() + xag.num_pos();
-    std::vector<WireRef> wires;
+    std::vector<Qubit> wires;
     wires.reserve(num_qubits);
     for (uint32_t i = 0u; i < num_qubits; ++i) {
         wires.emplace_back(circuit.create_qubit());

--- a/lib/Utils/Visualization/string_utf8.cpp
+++ b/lib/Utils/Visualization/string_utf8.cpp
@@ -84,226 +84,312 @@ inline void merge_chars(char32_t& c0, char32_t c1)
     }
 }
 
-struct DiagramOp {
-    uint32_t left_col;
-    uint32_t right_col;
-    uint32_t num_targets;
-    std::vector<uint32_t> wires;
-    std::vector<WireRef> cbits;
+class Diagram {
+public:
+    Diagram(uint32_t num_qubits, uint32_t num_cbits, uint32_t num_cols)
+        : num_rows_((2 * (num_qubits + num_cbits)) + 1)
+        , num_cols_(num_cols)
+        , rows_(num_rows_, std::u32string(num_cols, U' '))
+    {
+        for (uint32_t i = 0; i < num_qubits; ++i) {
+            std::u32string& row = rows_.at((2 * i) + 1);
+            std::fill(row.begin(), row.end(), U'─');
+        }
+        for (uint32_t i = num_qubits; i < num_qubits + num_cbits; ++i) {
+            std::u32string& row = rows_.at((2 * i) + 1);
+            std::fill(row.begin(), row.end(), U'═');
+        }
+    }
 
-    DiagramOp(std::vector<uint32_t> const& wires, uint32_t num_targets)
-        : num_targets(num_targets), wires(wires)
+    uint32_t wire_to_row(Qubit qubit) const
+    {
+        return (2u * (qubit)) + 1u;
+    }
+
+    uint32_t wire_to_row(Cbit cbit) const
+    {
+        return rows_.size() - 2;
+    }
+
+    auto& at(uint32_t row, uint32_t col)
+    {
+        assert(row < num_rows_);
+        assert(col < num_cols_);
+        return rows_.at(row).at(col);
+    }
+
+    std::u32string& row(uint32_t row)
+    {
+        assert(row < num_rows_);
+        return rows_.at(row);
+    }
+
+private:
+    uint32_t const num_rows_;
+    uint32_t const num_cols_;
+    std::vector<std::u32string> rows_;
+};
+
+class DiagramOp {
+public:
+    DiagramOp(uint32_t num_targets, std::vector<Qubit> const& qubits, 
+        std::vector<Cbit> const& cbits)
+        : num_targets_(num_targets), qubits_(qubits), cbits_(cbits)
     {}
 
     uint32_t num_controls() const
     {
-        return wires.size() - num_targets;
+        return qubits_.size() - num_targets();
+    }
+
+    uint32_t num_targets() const
+    {
+        return num_targets_;
+    }
+
+    void set_cols(uint32_t left_col)
+    {
+        left_col_ = left_col;
+        right_col_ = left_col_ + width() - 1;
     }
 
     virtual uint32_t width() const = 0;
 
-    virtual void draw(std::vector<std::u32string>& lines) const = 0;
+    virtual void draw(Diagram& diagram) = 0;
+
+protected:
+    uint32_t left_col_;
+    uint32_t right_col_;
+    uint32_t num_targets_;
+    std::vector<Qubit> qubits_;
+    std::vector<Cbit> cbits_;
 };
 
-struct Box : public DiagramOp {
+class Box : public DiagramOp {
+public:
+
+    Box(uint32_t num_targets, std::vector<Qubit> const& qubits, 
+        std::vector<Cbit> const& cbits, std::string_view label) 
+        : DiagramOp(num_targets, qubits, cbits), label(label)
+    { }
+
+    virtual uint32_t width() const override
+    {
+        return label.size() + 2u + (num_controls() > 0);
+    }
+
+    virtual void draw(Diagram& diagram) override
+    {
+        auto const [min, max] =
+            std::minmax_element(qubits_.begin(), qubits_.end());
+        set_vertical_positions(diagram, *min, *max);
+        draw_box(diagram);
+        draw_targets(diagram);
+        draw_controls(diagram);
+        draw_cbits(diagram);
+        draw_label(diagram);
+    }
+
+protected:
+    void set_vertical_positions(Diagram const& diagram, Qubit top, Qubit bot) 
+    {
+        box_top = diagram.wire_to_row(top) - 1u;
+        box_bot = diagram.wire_to_row(bot) + 1u;
+        box_mid = (box_top + box_bot) / 2u;
+    }
+
+    void draw_box(Diagram& diagram) const
+    {
+        // Draw top and bottom
+        for (uint32_t i = left_col_ + 1; i < right_col_; ++i) {
+            diagram.at(box_top, i) = U'─';
+            diagram.at(box_bot, i) = U'─';
+        }
+        // Draw sides
+        for (uint32_t i = box_top + 1; i < box_bot; ++i) {
+            auto left = diagram.row(i).begin() + left_col_;
+            auto right = diagram.row(i).begin() + right_col_;
+            *left = U'│';
+            *right = U'│';
+            std::fill(left + 1, right, U' ');
+        }
+        // Draw corners
+        merge_chars(diagram.at(box_top, left_col_), U'╭');
+        merge_chars(diagram.at(box_bot, left_col_), U'╰');
+        merge_chars(diagram.at(box_top, right_col_), U'╮');
+        merge_chars(diagram.at(box_bot, right_col_), U'╯');
+    }
+
+    void draw_targets(Diagram& diagram) const
+    {
+        std::for_each(qubits_.begin(), qubits_.begin() + num_targets(),
+        [&](Qubit qubit) {
+            uint32_t const row = diagram.wire_to_row(qubit);
+            diagram.at(row, left_col_) = U'┤';
+            diagram.at(row, right_col_) = U'├';
+        });
+    }
+
+    virtual void draw_controls(Diagram& diagram) const
+    {
+        std::for_each(qubits_.begin() + num_targets(), qubits_.end(),
+        [&](Qubit qubit) {
+            uint32_t const row = diagram.wire_to_row(qubit);
+            bool is_complemented = qubit.polarity() == Qubit::Polarity::negative;
+            diagram.at(row, left_col_) = U'┤';
+            diagram.at(row, left_col_ + 1) = is_complemented ? U'◯' : U'●';
+            diagram.at(row, right_col_) = U'├';
+        });
+    }
+
+    virtual void draw_cbits(Diagram& diagram) const
+    {
+        uint32_t const mid_col = (left_col_ + right_col_) / 2;
+        for (Cbit const cbit : cbits_) {
+            uint32_t const row = diagram.wire_to_row(cbit);
+            std::u32string const wire_label = fmt::format(U"{:>2}", cbit.uid());
+            bool is_complemented = cbit.polarity() == Cbit::Polarity::negative;
+            diagram.at(row, mid_col) = is_complemented ? U'◯' : U'●';
+            for (uint32_t i = box_bot + 1; i < row; ++i) {
+                merge_chars(diagram.at(i, mid_col), U'║');
+            }
+            diagram.at(box_bot, mid_col) = U'╥';
+            std::copy(wire_label.begin(), wire_label.end(), 
+                      diagram.row(row + 1).begin() + (mid_col - 1));
+        }
+    }
+
+    virtual void draw_label(Diagram& diagram) const
+    {
+        uint32_t const label_start = left_col_ + 1 + (num_controls() > 0);
+        std::copy(label.begin(), label.end(), 
+                  diagram.row(box_mid).begin() + label_start);
+    }
+
     uint32_t box_top;
     uint32_t box_mid;
     uint32_t box_bot;
     std::string label;
-
-    Box(std::vector<uint32_t> const& wires, uint32_t num_targets, std::string_view label) 
-        : DiagramOp(wires, num_targets), label(label)
-    {
-        auto const [min, max] = std::minmax_element(wires.begin(), wires.end());
-        box_top = (2 * (*min >> 1));
-        box_bot = (2 * (*max >> 1)) + 2;
-        box_mid = (box_top + box_bot) / 2;
-    }
-
-    virtual uint32_t width() const override
-    {
-        return label.size() + 2 + (num_controls() > 0);
-    }
-
-    virtual void draw(std::vector<std::u32string>& lines) const override
-    {
-        draw_box(lines);
-        draw_targets(lines);
-        draw_controls(lines);
-        draw_cbits(lines);
-        draw_label(lines);
-    }
-
-    void draw_box(std::vector<std::u32string>& lines) const
-    {
-        // Draw top and bottom
-        for (uint32_t i = left_col + 1; i < right_col; ++i) {
-            lines.at(box_top).at(i) = U'─';
-            lines.at(box_bot).at(i) = U'─';
-        }
-        // Draw sides
-        for (uint32_t i = box_top + 1; i < box_bot; ++i) {
-            auto left = lines.at(i).begin() + left_col;
-            auto right = lines.at(i).begin() + right_col;
-            *left = U'│';
-            *right = U'│';
-            std::fill(++left, right, U' ');
-        }
-        // Draw corners
-        merge_chars(lines.at(box_top).at(left_col), U'╭');
-        merge_chars(lines.at(box_bot).at(left_col), U'╰');
-        merge_chars(lines.at(box_top).at(right_col), U'╮');
-        merge_chars(lines.at(box_bot).at(right_col), U'╯');
-    }
-
-    void draw_targets(std::vector<std::u32string>& lines) const
-    {
-        std::for_each(wires.begin(), wires.begin() + num_targets,
-        [&](uint32_t wire) {
-            uint32_t const line = (2 * (wire >> 1)) + 1;
-            lines.at(line).at(left_col) = U'┤';
-            lines.at(line).at(right_col) = U'├';
-        });
-    }
-
-    virtual void draw_controls(std::vector<std::u32string>& lines) const
-    {
-        std::for_each(wires.begin() + num_targets, wires.end(),
-        [&](uint32_t wire) {
-            uint32_t const line = (2 * (wire >> 1)) + 1;
-            lines.at(line).at(left_col) = U'┤';
-            lines.at(line).at(left_col + 1) = wire & 1 ? U'◯' : U'●';
-            lines.at(line).at(right_col) = U'├';
-        });
-    }
-
-    virtual void draw_cbits(std::vector<std::u32string>& lines) const
-    {
-        uint32_t const mid_col = (left_col + right_col) / 2;
-        uint32_t const cbit_line = lines.size() - 2;
-        for (WireRef const wire : cbits) {
-            std::u32string const wire_label = fmt::format(U"{:>2}", wire.uid());
-            lines.at(cbit_line).at(mid_col) = wire.is_complemented() ? U'◯' : U'●';
-            for (uint32_t i = box_bot + 1; i < cbit_line; ++i) {
-                merge_chars(lines.at(i).at(mid_col), U'║');
-            }
-            lines.at(box_bot).at(mid_col) = U'╥';
-            std::copy(wire_label.begin(), wire_label.end(), 
-                      lines.at(cbit_line + 1).begin() + (mid_col - 1));
-        }
-    }
-
-    virtual void draw_label(std::vector<std::u32string>& lines) const
-    {
-        uint32_t const label_start = left_col + 1 + (num_controls() > 0);
-        std::copy(label.begin(), label.end(), 
-                  lines.at(box_mid).begin() + label_start);
-    }
 };
 
-struct ControlledBox : public Box {
-
-    ControlledBox(std::vector<uint32_t> const& wires, uint32_t num_targets, std::string_view label) 
-        : Box(wires, num_targets, label)
-    {
-        auto const [min, max] = std::minmax_element(wires.begin(), wires.begin() + num_targets);
-        box_top = (2 * (*min >> 1));
-        box_bot = (2 * (*max >> 1)) + 2;
-        box_mid = (box_top + box_bot) / 2;
-    }
+class ControlledBox : public Box {
+public:
+    ControlledBox(uint32_t num_targets, std::vector<Qubit> const& qubits, 
+        std::vector<Cbit> const& cbits, std::string_view label) 
+        : Box(num_targets, qubits, cbits, label)
+    { }
 
     virtual uint32_t width() const override
     {
         return label.size() + 2;
     }
 
-    virtual void draw_controls(std::vector<std::u32string>& lines) const override
+    virtual void draw(Diagram& diagram) override
     {
-        uint32_t const mid_col = (left_col + right_col) / 2;
-        std::for_each(wires.begin() + num_targets, wires.end(),
-        [&](uint32_t wire) {
-            uint32_t const line = (2 * (wire >> 1)) + 1;
-            lines.at(line).at(mid_col) = wire & 1 ? U'◯' : U'●';
-            if (line < box_top) {
-                for (uint32_t i = line + 1; i < box_top; ++i) {
-                    merge_chars(lines.at(i).at(mid_col), U'│');
+        auto const [min, max] =
+            std::minmax_element(qubits_.begin(), qubits_.begin() + num_targets());
+        set_vertical_positions(diagram, *min, *max);
+        draw_box(diagram);
+        draw_targets(diagram);
+        draw_controls(diagram);
+        draw_cbits(diagram);
+        draw_label(diagram);
+    }
+
+private:
+    virtual void draw_controls(Diagram& diagram) const override
+    {
+        uint32_t const mid_col = (left_col_ + right_col_) / 2;
+        std::for_each(qubits_.begin() + num_targets(), qubits_.end(),
+        [&](Qubit qubit) {
+            uint32_t const row = diagram.wire_to_row(qubit);
+            bool is_complemented = qubit.polarity() == Qubit::Polarity::negative;
+            diagram.at(row, mid_col) = is_complemented ? U'◯' : U'●';
+            if (row < box_top) {
+                for (uint32_t i = row + 1; i < box_top; ++i) {
+                    merge_chars(diagram.at(i, mid_col), U'│');
                 }
-                lines.at(box_top).at(mid_col) = U'┴';
+                diagram.at(box_top, mid_col) = U'┴';
             } else {
-                for (uint32_t i = box_top + 1; i < line; ++i) {
-                    merge_chars(lines.at(i).at(mid_col), U'│');
+                for (uint32_t i = box_top + 1; i < row; ++i) {
+                    merge_chars(diagram.at(i, mid_col), U'│');
                 }
-                lines.at(box_bot).at(mid_col) = U'┬';
+                diagram.at(box_bot, mid_col) = U'┬';
             }
         });
     }
 
-    virtual void draw_label(std::vector<std::u32string>& lines) const override
+    virtual void draw_label(Diagram& diagram) const override
     {
         std::copy(label.begin(), label.end(),
-                  lines.at(box_mid).begin() + left_col + 1);
+                  diagram.row(box_mid).begin() + left_col_ + 1);
     }
 };
 
-struct MeasureBox : public Box {
-    MeasureBox(std::vector<uint32_t> const& wires) 
-        : Box(wires, 1, "m")
+class MeasureBox : public Box {
+public:
+    MeasureBox(std::vector<Qubit> const& qubits, std::vector<Cbit> const& cbits) 
+        : Box(1u, qubits, cbits, "m")
     { }
 
-    virtual void draw_cbits(std::vector<std::u32string>& lines) const
+private:
+    virtual void draw_cbits(Diagram& diagram) const
     {
-        uint32_t const mid_col = (left_col + right_col) / 2;
-        uint32_t const cbit_line = lines.size() - 2;
-        lines.at(box_bot).at(mid_col) = U'╥';
-        for (uint32_t i = box_bot + 1; i < cbit_line; ++i) {
-            merge_chars(lines.at(i).at(mid_col), U'║');
+        uint32_t const mid_col = (left_col_ + right_col_) / 2;
+        uint32_t const row = diagram.wire_to_row(cbits_.back());
+        diagram.at(box_bot, mid_col) = U'╥';
+        for (uint32_t i = box_bot + 1; i < row; ++i) {
+            merge_chars(diagram.at(i, mid_col), U'║');
         }
-        lines.at(cbit_line).at(left_col + 1) = U'V';
-        std::u32string const wire_label = fmt::format(U"{:>2}", cbits.at(0).uid());
+        diagram.at(row, left_col_ + 1) = U'V';
+        std::u32string const wire_label = fmt::format(U"{:>2}", cbits_.at(0).uid());
         std::copy(wire_label.begin(), wire_label.end(), 
-                  lines.at(cbit_line + 1).begin() + (mid_col - 1));
+                  diagram.row(row + 1).begin() + (mid_col - 1));
     }
 };
 
-struct DiagramSwap : public DiagramOp {
-
-    DiagramSwap(std::vector<uint32_t> const& wires, uint32_t num_targets)
-        : DiagramOp(wires, num_targets)
+class DiagramSwap : public DiagramOp {
+public:
+    DiagramSwap(std::vector<Qubit> const& qubits, std::vector<Cbit> const& cbits)
+        : DiagramOp(2u, qubits, cbits)
     {}
+
     virtual uint32_t width() const override
     {
         return 3u;
     }
 
-    virtual void draw(std::vector<std::u32string>& lines) const override
+    virtual void draw(Diagram& diagram) override
     {
-        uint32_t const mid_col = left_col + 1;
-        uint32_t const target_row0 = (2 * (wires.at(0) >> 1)) + 1;
-        uint32_t const target_row1 = (2 * (wires.at(1) >> 1)) + 1;
-        lines.at(target_row0).at(mid_col) = U'╳';
+        uint32_t const mid_col = left_col_ + 1;
+        uint32_t const target_row0 = diagram.wire_to_row(qubits_.at(0));
+        uint32_t const target_row1 = diagram.wire_to_row(qubits_.at(1));
+        diagram.at(target_row0, mid_col) = U'╳';
         for (uint32_t i = target_row0 + 1; i < target_row1; ++i) {
-            merge_chars(lines.at(i).at(mid_col), U'│');
+            merge_chars(diagram.at(i, mid_col), U'│');
         }
-        lines.at(target_row1).at(mid_col) = U'╳';
-        draw_controls(lines);
+        diagram.at(target_row1, mid_col) = U'╳';
+        draw_controls(diagram);
     }
 
-    void draw_controls(std::vector<std::u32string>& lines) const
+private:
+    void draw_controls(Diagram& diagram) const
     {
-        uint32_t const mid_col = left_col + 1;
-        uint32_t const target_row0 = (2 * (wires.at(0) >> 1)) + 1;
-        uint32_t const target_row1 = (2 * (wires.at(1) >> 1)) + 1;
-        std::for_each(wires.begin() + num_targets, wires.end(),
-        [&](uint32_t wire) {
-            uint32_t const line = (2 * (wire >> 1)) + 1;
-            lines.at(line).at(mid_col) = wire & 1 ? U'◯' : U'●';
-            if (line < target_row0) {
-                for (uint32_t i = line + 1; i < target_row0; ++i) {
-                    merge_chars(lines.at(i).at(mid_col), U'│');
+        uint32_t const mid_col = left_col_ + 1;
+        uint32_t const target_row0 = diagram.wire_to_row(qubits_.at(0));
+        uint32_t const target_row1 = diagram.wire_to_row(qubits_.at(1));
+        std::for_each(qubits_.begin() + num_targets(), qubits_.end(),
+        [&](Qubit qubit) {
+            uint32_t const row = diagram.wire_to_row(qubit);
+            bool is_complemented = qubit.polarity() == Qubit::Polarity::negative;
+            diagram.at(row, mid_col) = is_complemented ? U'◯' : U'●';
+            if (row < target_row0) {
+                for (uint32_t i = row + 1; i < target_row0; ++i) {
+                    merge_chars(diagram.at(i, mid_col), U'│');
                 }
             } else {
-                for (uint32_t i = target_row1 + 1; i < line; ++i) {
-                    merge_chars(lines.at(i).at(mid_col), U'│');
+                for (uint32_t i = target_row1 + 1; i < row; ++i) {
+                    merge_chars(diagram.at(i, mid_col), U'│');
                 }
             }
         });
@@ -316,19 +402,13 @@ std::string to_string_utf8(Circuit const& circuit, uint32_t const max_rows)
     if (circuit.num_wires() == 0) {
         return "";
     }
-    // Create a mapping between circuit wires and diagram wires
     uint32_t const num_dwire = circuit.num_qubits() + (circuit.num_cbits() > 0);
-    std::vector<uint32_t> wire_to_dwire(circuit.num_wires(), num_dwire - 1);
     uint32_t curr_dwire = 0;
     std::size_t prefix_size = 0;
     std::vector<std::string> prefix((2 * num_dwire) + 1, "");
-    circuit.foreach_wire([&](WireRef wref, Wire const& wire) {
-        if (wref.kind() == Wire::Kind::classical) {
-            return;
-        }
-        wire_to_dwire.at(wref) = curr_dwire;
-        prefix.at((2 * curr_dwire++) + 1) = wire.name + " : ";
-        prefix_size = std::max(prefix_size, wire.name.size() + 3);
+    circuit.foreach_qubit([&](std::string_view name) {
+        prefix.at((2 * curr_dwire++) + 1) = fmt::format("{} : ", name);
+        prefix_size = std::max(prefix_size, name.size() + 3);
     });
     // Separete the intructions in layers.  Each layer must contain gates that
     // can be drawn in the same diagram layer.  For example, if I have a
@@ -339,31 +419,28 @@ std::string to_string_utf8(Circuit const& circuit, uint32_t const max_rows)
     std::vector<uint32_t> layer_width;
     std::vector<int> wire_layer(num_dwire, -1);
     circuit.foreach_instruction([&](InstRef ref, Instruction const& inst) {
-        std::vector<uint32_t> diagram_wires;
-        std::vector<WireRef> cbits;
-        inst.foreach_target([&](WireRef wire) {
-            diagram_wires.push_back(wire_to_dwire.at(wire) << 1);
+        std::vector<Qubit> qubits;
+        std::vector<Cbit> cbits;
+        inst.foreach_target([&](Qubit target) {
+            qubits.push_back(target);
         });
-        std::sort(diagram_wires.begin(), diagram_wires.end());
-        uint32_t const min_target = diagram_wires.front();
-        uint32_t const max_target = diagram_wires.back();
+        std::sort(qubits.begin(), qubits.end());
+        uint32_t const min_target = qubits.front();
+        uint32_t const max_target = qubits.back();
         uint32_t min_dwire = min_target;
         uint32_t max_dwire = max_target;
         bool overlap = false;
-        inst.foreach_control([&](WireRef wire) {
-            uint32_t const control = (wire_to_dwire.at(wire) << 1);
-            diagram_wires.emplace_back(control | wire.is_complemented());
+        inst.foreach_control([&](Qubit control) {
+            qubits.push_back(control);
             if (control > min_target && control < max_target) {
                 overlap = true;
             }
-            min_dwire = std::min(control, min_dwire);
-            max_dwire = std::max(control, max_dwire);
+            min_dwire = std::min(control.uid(), min_dwire);
+            max_dwire = std::max(control.uid(), max_dwire);
         });
-        min_dwire >>= 1;
-        max_dwire >>= 1;
         if (inst.num_cbits() > 0) {
-            inst.foreach_cbit([&](WireRef wire) {
-                cbits.push_back(wire);
+            inst.foreach_cbit([&](Cbit cbit) {
+                cbits.push_back(cbit);
             });
             max_dwire = wire_layer.size() - 1;
         }
@@ -372,15 +449,14 @@ std::string to_string_utf8(Circuit const& circuit, uint32_t const max_rows)
         std::string label = fmt::format("{: ^{}}", name, name.size() + (2 * padding));
         std::unique_ptr<DiagramOp> shape = nullptr;
         if (overlap) {
-            shape = std::make_unique<Box>(diagram_wires, inst.num_targets(), inst.name());
+            shape = std::make_unique<Box>(inst.num_targets(), qubits, cbits, label);
         } else if (inst.is_a<Op::Swap>()) {
-            shape = std::make_unique<DiagramSwap>(diagram_wires, inst.num_targets());
+            shape = std::make_unique<DiagramSwap>(qubits, cbits);
         } else if (inst.is_a<Op::Measure>()) {
-            shape = std::make_unique<MeasureBox>(diagram_wires);
+            shape = std::make_unique<MeasureBox>(qubits, cbits);
         } else {
-            shape = std::make_unique<ControlledBox>(diagram_wires, inst.num_targets(), label);
+            shape = std::make_unique<ControlledBox>(inst.num_targets(), qubits, cbits, label);
         }
-        shape->cbits = cbits;
         
         int layer = -1;
         for (uint32_t i = min_dwire; i <= max_dwire; ++i) {
@@ -405,9 +481,8 @@ std::string to_string_utf8(Circuit const& circuit, uint32_t const max_rows)
     std::vector<uint32_t> cutting_point;
     for (uint32_t layer = 0u; layer < layers.size(); ++layer) {
         for (InstRef const ref : layers.at(layer)) {
-            auto const& box = boxes.at(ref);
-            box->left_col = curr_width + (layer_width.at(layer) - box->width())/2u;
-            box->right_col = box->left_col + box->width() - 1;
+            auto& box = boxes.at(ref);
+            box->set_cols(curr_width + (layer_width.at(layer) - box->width())/2u);
         }
         if ((acc_width + layer_width.at(layer)) >= (max_rows - 1)) {
             cutting_point.push_back(curr_width);
@@ -419,39 +494,27 @@ std::string to_string_utf8(Circuit const& circuit, uint32_t const max_rows)
     cutting_point.push_back(curr_width);
 
     // Initialize the diagram with the wires 
-    uint32_t const num_lines = (2 * num_dwire) + 1;
-    std::vector<std::u32string> lines(num_lines, std::u32string(curr_width, U' '));
-    for (uint32_t i = 0; i < num_dwire - 1; ++i) {
-        std::u32string& line = lines.at((2 * i) + 1);
-        std::fill(line.begin(), line.end(), U'─');
-    }
-    if (circuit.num_cbits() > 0) {
-        std::u32string& line = lines.at((2 * (num_dwire - 1)) + 1);
-        std::fill(line.begin(), line.end(), U'═');
-    } else {
-        std::u32string& line = lines.at((2 * (num_dwire - 1)) + 1);
-        std::fill(line.begin(), line.end(), U'─');
-    }
-
+    uint32_t const num_rows = (2 * num_dwire) + 1;
+    Diagram diagram(circuit.num_qubits(), (circuit.num_cbits() > 0), curr_width);
     // Draw boxes
     for (auto const& box : boxes) {
-        box->draw(lines);
+        box->draw(diagram);
     }
 
     std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
     std::string str;
-    str.reserve(curr_width * num_lines * 4);
+    str.reserve(curr_width * num_rows * 4);
 
     uint32_t start = 0;
     for (uint32_t i = 0; i < cutting_point.size(); ++i) {
         if (i > 0) {
             str += fmt::format("\n{:#^{}}\n\n", "", max_rows);
         }
-        for (uint32_t line = 0; line < lines.size(); ++line) {
-            auto being = lines.at(line).data() + start;
-            auto end = lines.at(line).data() + cutting_point.at(i);
+        for (uint32_t row = 0; row < num_rows; ++row) {
+            auto being = diagram.row(row).data() + start;
+            auto end = diagram.row(row).data() + cutting_point.at(i);
             if (i == 0) {
-                str += fmt::format("{: >{}}", prefix.at(line), prefix_size);
+                str += fmt::format("{: >{}}", prefix.at(row), prefix_size);
             }
             str += conv.to_bytes(being, end);
             if (i + 1 < cutting_point.size()) {

--- a/python/tweedledum/CMakeLists.txt
+++ b/python/tweedledum/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(_tweedledum PUBLIC
     classical/kitty.cpp
     classical/mockturtle.cpp
     classical/utils.cpp
+    ir/cbit.cpp
+    ir/qubit.cpp
     ir/instruction.cpp
     ir/circuit.cpp
     operators/extension.cpp

--- a/python/tweedledum/bindings.cpp
+++ b/python/tweedledum/bindings.cpp
@@ -24,6 +24,8 @@ PYBIND11_MODULE(_tweedledum, module)
 
     // IR
     py::module ir = module.def_submodule("ir", "Tweedledum intermediate representation");
+    init_Cbit(ir);
+    init_Qubit(ir);
     init_Instruction(ir);
     init_Circuit(ir);
 

--- a/python/tweedledum/bindings.h
+++ b/python/tweedledum/bindings.h
@@ -12,8 +12,10 @@ void init_mockturtle(pybind11::module& module);
 void init_utils(pybind11::module& module);
 
 // IR
+void init_Cbit(pybind11::module& module);
 void init_Circuit(pybind11::module& module);
 void init_Instruction(pybind11::module& module);
+void init_Qubit(pybind11::module& module);
 
 // Operators
 void init_ext_operators(pybind11::module& module);

--- a/python/tweedledum/ir/cbit.cpp
+++ b/python/tweedledum/ir/cbit.cpp
@@ -1,0 +1,26 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <tweedledum/IR/Cbit.h>
+
+void init_Cbit(pybind11::module& module)
+{
+    using namespace tweedledum;
+    namespace py = pybind11;
+
+    py::class_<Cbit> cbit(module, "Cbit");
+    cbit.def("polarity", &Cbit::polarity)
+        .def("uid", &Cbit::uid)
+        .def("__index__", [](Cbit const& bit) { return static_cast<uint32_t>(bit); })
+        .def("__invert__", [](Cbit const& lhs) { return !lhs; })
+        .def(py::self == py::self)
+        .def(py::self != py::self);
+
+    py::enum_<Cbit::Polarity>(cbit, "Polarity")
+        .value("negative", Cbit::Polarity::negative)
+        .value("positive", Cbit::Polarity::positive)
+        .export_values();
+}

--- a/python/tweedledum/ir/circuit.cpp
+++ b/python/tweedledum/ir/circuit.cpp
@@ -7,32 +7,12 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 #include <tweedledum/Operators/All.h>
-#include <tweedledum/Utils/Visualization/string_utf8.h>
+// #include <tweedledum/Utils/Visualization/string_utf8.h>
 
 void init_Circuit(pybind11::module& module)
 {
     using namespace tweedledum;
     namespace py = pybind11;
-
-    py::class_<Wire> wire(module, "Wire");
-    py::enum_<Wire::Kind>(wire, "Kind")
-        .value("classical", Wire::Kind::classical)
-        .value("quantum", Wire::Kind::quantum)
-        .export_values();
-
-    py::class_<WireRef> wref(module, "WireRef");
-    wref.def("kind", &WireRef::kind)
-        .def("polarity", &WireRef::polarity)
-        .def("uid", &WireRef::uid)
-        .def("__index__", [](WireRef const& ref) { return static_cast<uint32_t>(ref); })
-        .def("__invert__", [](WireRef const& lhs) { return !lhs; })
-        .def(py::self == py::self)
-        .def(py::self != py::self);
-
-    py::enum_<WireRef::Polarity>(wref, "Polarity")
-        .value("negative", WireRef::Polarity::negative)
-        .value("positive", WireRef::Polarity::positive)
-        .export_values();
 
     py::class_<Circuit>(module, "Circuit")
         .def(py::init<>())
@@ -47,36 +27,58 @@ void init_Circuit(pybind11::module& module)
         .def("request_ancilla", &Circuit::request_ancilla)
         .def("release_ancilla", &Circuit::release_ancilla)
         // Extension Operators
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::TruthTable const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Unitary const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::TruthTable const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Unitary const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
         // Ising Operators
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Rxx const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Ryy const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Rzz const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Rxx const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Ryy const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Rzz const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
         // Meta Operators
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Barrier const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Barrier const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
         // Standard Operators
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::H const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Measure const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::P const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Rx const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Ry const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Rz const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::S const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Sdg const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Swap const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::T const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Tdg const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::X const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Y const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Z const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(Instruction const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::H const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Measure const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::P const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Rx const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Ry const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Rz const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::S const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Sdg const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Swap const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::T const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Tdg const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::X const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Y const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Op::Z const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(Instruction const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
         .def("apply_operator", static_cast<InstRef (Circuit::*)(Instruction const&)>(&Circuit::apply_operator))
-        .def("apply_operator", static_cast<InstRef (Circuit::*)(pybind11::object const&, std::vector<WireRef> const&)>(&Circuit::apply_operator))
+        .def("apply_operator", static_cast<InstRef (Circuit::*)(pybind11::object const&, std::vector<Qubit> const&, std::vector<Cbit> const&)>(&Circuit::apply_operator),
+             py::arg("optor"), py::arg("qubits"), py::arg("cbits") = std::vector<Cbit>())
         .def("append", &Circuit::append)
         // Python stuff
         .def("__iter__", [](Circuit const& c) { return py::make_iterator(c.py_begin(), c.py_end()); }, py::keep_alive<0, 1>())
-        .def("__len__", &Circuit::size)
-        .def("__str__", [](Circuit const& c) { return to_string_utf8(c); });
+        .def("__len__", &Circuit::size);
+     //    .def("__str__", [](Circuit const& c) { return to_string_utf8(c); });
 
 }

--- a/python/tweedledum/ir/circuit.cpp
+++ b/python/tweedledum/ir/circuit.cpp
@@ -7,7 +7,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 #include <tweedledum/Operators/All.h>
-// #include <tweedledum/Utils/Visualization/string_utf8.h>
+#include <tweedledum/Utils/Visualization/string_utf8.h>
 
 void init_Circuit(pybind11::module& module)
 {
@@ -78,7 +78,7 @@ void init_Circuit(pybind11::module& module)
         .def("append", &Circuit::append)
         // Python stuff
         .def("__iter__", [](Circuit const& c) { return py::make_iterator(c.py_begin(), c.py_end()); }, py::keep_alive<0, 1>())
-        .def("__len__", &Circuit::size);
-     //    .def("__str__", [](Circuit const& c) { return to_string_utf8(c); });
+        .def("__len__", &Circuit::size)
+        .def("__str__", [](Circuit const& c) { return to_string_utf8(c); });
 
 }

--- a/python/tweedledum/ir/circuit.h
+++ b/python/tweedledum/ir/circuit.h
@@ -7,16 +7,18 @@
 #include "../operators/operators.h"
 
 #include <pybind11/pybind11.h>
+#include <tweedledum/IR/Cbit.h>
 #include <tweedledum/IR/Circuit.h>
-#include <tweedledum/IR/Wire.h>
+#include <tweedledum/IR/Qubit.h>
 #include <vector>
 
 namespace tweedledum {
 
 template<>
-inline InstRef Circuit::apply_operator(pybind11::object const& obj, std::vector<WireRef> const& wires)
+inline InstRef Circuit::apply_operator(pybind11::object const& obj,
+    std::vector<Qubit> const& qubits, std::vector<Cbit> const& cbits)
 {
-    return this->apply_operator(python::PyOperator(obj), wires);
+    return this->apply_operator(python::PyOperator(obj), qubits, cbits);
 }
 
 } // namespace tweedledum

--- a/python/tweedledum/ir/instruction.cpp
+++ b/python/tweedledum/ir/instruction.cpp
@@ -21,8 +21,8 @@ void init_Instruction(pybind11::module& module)
         .def("num_cbits", &Instruction::num_cbits)
         .def("num_wires", &Instruction::num_wires)
         .def("num_controls", &Instruction::num_controls)
+        .def("cbits", &Instruction::cbits)
         .def("qubits", &Instruction::qubits)
-        .def("wires", &Instruction::wires)
         .def("py_op", [](Instruction const& i) {
             auto const& temp = i.cast<python::PyOperator>();
             return temp.obj();

--- a/python/tweedledum/ir/qubit.cpp
+++ b/python/tweedledum/ir/qubit.cpp
@@ -1,0 +1,26 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <tweedledum/IR/Qubit.h>
+
+void init_Qubit(pybind11::module& module)
+{
+    using namespace tweedledum;
+    namespace py = pybind11;
+
+    py::class_<Qubit> qubit(module, "Qubit");
+    qubit.def("polarity", &Qubit::polarity)
+        .def("uid", &Qubit::uid)
+        .def("__index__", [](Qubit const& bit) { return static_cast<uint32_t>(bit); })
+        .def("__invert__", [](Qubit const& lhs) { return !lhs; })
+        .def(py::self == py::self)
+        .def(py::self != py::self);
+
+    py::enum_<Qubit::Polarity>(qubit, "Polarity")
+        .value("negative", Qubit::Polarity::negative)
+        .value("positive", Qubit::Polarity::positive)
+        .export_values();
+}

--- a/python/tweedledum/passes/passes.cpp
+++ b/python/tweedledum/passes/passes.cpp
@@ -22,96 +22,100 @@ void init_Passes(pybind11::module& module)
     module.def("depth", &depth, "Compute depth pass.");
 
     // Decomposition
-    module.def("barenco_decomp", py::overload_cast<Circuit const&, nlohmann::json const&>(&barenco_decomp),
-    py::arg("circuit"), py::arg("config") = nlohmann::json(),
-    "Barrenco decomposition pass.");
+    module.def("barenco_decomp", 
+        py::overload_cast<Circuit const&, nlohmann::json const&>(&barenco_decomp),
+        py::arg("circuit"), py::arg("config") = nlohmann::json(),
+        "Barrenco decomposition pass.");
 
-    module.def("parity_decomp", py::overload_cast<Circuit const&>(&parity_decomp),
-    "Parity operators decomposition pass.");
+    module.def("parity_decomp",
+        py::overload_cast<Circuit const&>(&parity_decomp),
+        "Parity operators decomposition pass.");
 
     // Optimization
-    module.def("linear_resynth", &linear_resynth, py::arg("original"), py::arg("config") = nlohmann::json(),
-    "Resynthesize linear parts of the quantum circuit.");
+    module.def("linear_resynth", &linear_resynth, 
+        py::arg("original"), py::arg("config") = nlohmann::json(),
+        "Resynthesize linear parts of the quantum circuit.");
 
     module.def("phase_folding", &phase_folding, "Phase folding optimization.");
 
     // Synthesis 
-    module.def("decomp_synth",  py::overload_cast<std::vector<uint32_t> const&>(&decomp_synth),
-    "Reversible synthesis based on functional decomposition.");
+    module.def("decomp_synth",
+        py::overload_cast<std::vector<uint32_t> const&>(&decomp_synth),
+        "Reversible synthesis based on functional decomposition.");
 
-    module.def("decomp_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&,
-    std::vector<uint32_t> const&>(&decomp_synth),
-    "Reversible synthesis based on functional decomposition.");
+    module.def("decomp_synth", 
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, std::vector<uint32_t> const&>(&decomp_synth),
+        "Reversible synthesis based on functional decomposition.");
 
-    module.def("lhrs_synth",  py::overload_cast<mockturtle::xag_network const&, nlohmann::json const&>(&lhrs_synth),
-    py::arg("xag"), py::arg("config") = nlohmann::json(),
-    "LUT-based Hierarchical Synthesis from a XAG representation.");
+    module.def("lhrs_synth",
+        py::overload_cast<mockturtle::xag_network const&, nlohmann::json const&>(&lhrs_synth),
+        py::arg("xag"), py::arg("config") = nlohmann::json(),
+        "LUT-based Hierarchical Synthesis from a XAG representation.");
 
-    module.def("lhrs_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&, mockturtle::xag_network const&, nlohmann::json const&>(&lhrs_synth),
-    py::arg("circuit"), py::arg("qubits"), py::arg("xag"), py::arg("config") = nlohmann::json(),
-    "LUT-based Hierarchical Synthesis inplace from a XAG representation.");
+    module.def("lhrs_synth",
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, mockturtle::xag_network const&, nlohmann::json const&>(&lhrs_synth),
+        py::arg("circuit"), py::arg("qubits"), py::arg("cbits"), py::arg("xag"), py::arg("config") = nlohmann::json(),
+        "LUT-based Hierarchical Synthesis inplace from a XAG representation.");
 
-    module.def("linear_synth",  py::overload_cast<BMatrix const&, nlohmann::json const&>(&linear_synth),
-    py::arg("matrix"), py::arg("config") = nlohmann::json(),
-    "Synthesis of linear reversible circuits (CNOT synthesis).");
+    module.def("linear_synth",
+        py::overload_cast<BMatrix const&, nlohmann::json const&>(&linear_synth),
+        py::arg("matrix"), py::arg("config") = nlohmann::json(),
+        "Synthesis of linear reversible circuits (CNOT synthesis).");
 
-    module.def("linear_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&, BMatrix const&, nlohmann::json const&>(&linear_synth),
-    py::arg("circuit"), py::arg("qubits"), py::arg("matrix"), py::arg("config") = nlohmann::json(),
-    "Reversible synthesis based on functional decomposition.");
+    module.def("linear_synth",
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, BMatrix const&, nlohmann::json const&>(&linear_synth),
+        py::arg("circuit"), py::arg("qubits"), py::arg("cbits"), py::arg("matrix"), py::arg("config") = nlohmann::json(),
+        "Reversible synthesis based on functional decomposition.");
 
-    module.def("pkrm_synth", py::overload_cast<kitty::dynamic_truth_table const&, nlohmann::json const&>(&pkrm_synth),
-    py::arg("function"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit from a function by computing PKRM representation.");
+    module.def("pkrm_synth",
+        py::overload_cast<kitty::dynamic_truth_table const&, nlohmann::json const&>(&pkrm_synth),
+        py::arg("function"), py::arg("config") = nlohmann::json(),
+        "Synthesize a quantum circuit from a function by computing PKRM representation.");
 
-    module.def("pkrm_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&, kitty::dynamic_truth_table const&, nlohmann::json const&>(&pkrm_synth),
-    py::arg("circuit"), py::arg("qubits"), py::arg("function"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit inplace from a function by computing PKRM representation.");
+    module.def("pkrm_synth",
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, kitty::dynamic_truth_table const&, nlohmann::json const&>(&pkrm_synth),
+        py::arg("circuit"), py::arg("qubits"), py::arg("cbits"), py::arg("function"), py::arg("config") = nlohmann::json(),
+        "Synthesize a quantum circuit inplace from a function by computing PKRM representation.");
 
-    module.def("pkrm_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&, Instruction const&, nlohmann::json const&>(&pkrm_synth),
-    py::arg("circuit"), py::arg("qubits"), py::arg("inst"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit inplace from a Instruction by computing PKRM representation.");
+    module.def("pprm_synth", 
+        py::overload_cast<kitty::dynamic_truth_table const&, nlohmann::json const&>(&pprm_synth),
+        py::arg("function"), py::arg("config") = nlohmann::json(),
+        "Synthesize a quantum circuit from a function by computing PPRM representation.");
 
-    module.def("pkrm_synth",  py::overload_cast<mockturtle::xag_network const&, nlohmann::json const&>(&pkrm_synth),
-    py::arg("xag"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit from a XAG by computing PKRM representation.");
+    module.def("pprm_synth", 
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, kitty::dynamic_truth_table const&, nlohmann::json const&>(&pprm_synth),
+        py::arg("circuit"), py::arg("qubits"), py::arg("cbits"), py::arg("function"), py::arg("config") = nlohmann::json(),
+        "Synthesize a quantum circuit inplace from a function by computing PPRM representation.");
 
-    module.def("pkrm_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&, mockturtle::xag_network const&, nlohmann::json const&>(&pkrm_synth),
-    py::arg("circuit"), py::arg("qubits"), py::arg("xag"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit inplace from a XAG by computing PKRM representation.");
-    
-    module.def("pprm_synth",  py::overload_cast<kitty::dynamic_truth_table const&, nlohmann::json const&>(&pprm_synth),
-    py::arg("function"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit from a function by computing PPRM representation.");
+    module.def("spectrum_synth", 
+        py::overload_cast<kitty::dynamic_truth_table const&, nlohmann::json const&>(&spectrum_synth),
+        py::arg("function"), py::arg("config") = nlohmann::json(),
+        "Synthesize a quantum circuit from a function by computing the Rademacher-Walsh spectrum.");
 
-    module.def("pprm_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&, kitty::dynamic_truth_table const&, nlohmann::json const&>(&pprm_synth),
-    py::arg("circuit"), py::arg("qubits"), py::arg("function"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit inplace from a function by computing PPRM representation.");
+    module.def("spectrum_synth", 
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, kitty::dynamic_truth_table const&, nlohmann::json const&>(&spectrum_synth),
+        py::arg("circuit"), py::arg("qubits"), py::arg("cbits"), py::arg("function"), py::arg("config") = nlohmann::json(),
+        "Synthesize a quantum circuit inplace from a function by computing the Rademacher-Walsh spectrum.");
 
-    module.def("spectrum_synth",  py::overload_cast<kitty::dynamic_truth_table const&, nlohmann::json const&>(&spectrum_synth),
-    py::arg("function"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit from a function by computing the Rademacher-Walsh spectrum.");
+    module.def("transform_synth", 
+        py::overload_cast<std::vector<uint32_t> const&>(&transform_synth),
+        "Reversible synthesis based on symbolic transformation.");
 
-    module.def("spectrum_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&, kitty::dynamic_truth_table const&, nlohmann::json const&>(&spectrum_synth),
-    py::arg("circuit"), py::arg("qubits"), py::arg("function"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit inplace from a function by computing the Rademacher-Walsh spectrum.");
+    module.def("transform_synth", 
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, std::vector<uint32_t> const&>(&transform_synth),
+        "Reversible synthesis based on symbolic transformation.");
 
-    module.def("transform_synth",  py::overload_cast<std::vector<uint32_t> const&>(&transform_synth),
-    "Reversible synthesis based on symbolic transformation.");
+    module.def("xag_synth", 
+        py::overload_cast<mockturtle::xag_network const&, nlohmann::json const&>(&xag_synth),
+        py::arg("xag"), py::arg("config") = nlohmann::json(),
+        "Synthesize a quantum circuit from a XAG representation.");
 
-    module.def("transform_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&,
-    std::vector<uint32_t> const&>(&transform_synth),
-    "Reversible synthesis based on symbolic transformation.");
-
-    module.def("xag_synth",  py::overload_cast<mockturtle::xag_network const&, nlohmann::json const&>(&xag_synth),
-    py::arg("xag"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit from a XAG representation.");
-
-    module.def("xag_synth",  py::overload_cast<Circuit&, std::vector<WireRef> const&, mockturtle::xag_network const&, nlohmann::json const&>(&xag_synth),
-    py::arg("circuit"), py::arg("qubits"), py::arg("xag"), py::arg("config") = nlohmann::json(),
-    "Synthesize a quantum circuit inplace from a XAG representation.");
+    module.def("xag_synth",
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, mockturtle::xag_network const&, nlohmann::json const&>(&xag_synth),
+        py::arg("circuit"), py::arg("qubits"), py::arg("cbits"), py::arg("xag"), py::arg("config") = nlohmann::json(),
+        "Synthesize a quantum circuit inplace from a XAG representation.");
 
     // Utility
     module.def("shallow_duplicate", &shallow_duplicate,
-    "Creates a new circuit with same wires as the original.");
-
+        "Creates a new circuit with same wires as the original.");
 }

--- a/test/Generators/adder.cpp
+++ b/test/Generators/adder.cpp
@@ -32,8 +32,8 @@ TEST_CASE("Adder", "[adder][generators]")
 {
     using namespace tweedledum;
     Circuit circuit;
-    std::vector<WireRef> a_qubits;
-    std::vector<WireRef> b_qubits;
+    std::vector<Qubit> a_qubits;
+    std::vector<Qubit> b_qubits;
     uint32_t n = 4;
     for (uint32_t i = 0; i < n; ++i) {
         a_qubits.push_back(circuit.create_qubit(fmt::format("a{}", i)));
@@ -41,7 +41,7 @@ TEST_CASE("Adder", "[adder][generators]")
     for (uint32_t i = 0; i < n; ++i) {
         b_qubits.push_back(circuit.create_qubit(fmt::format("b{}", i)));
     }
-    WireRef carry = circuit.create_qubit();
+    Qubit carry = circuit.create_qubit();
     carry_ripple_adder_inplace(circuit, a_qubits, b_qubits, carry);
     CHECK(validate_adder(circuit, n));
 }

--- a/test/IR/Circuit.cpp
+++ b/test/IR/Circuit.cpp
@@ -11,9 +11,12 @@ TEST_CASE("Simple circuit functionality", "[circuit][ir]")
     using namespace tweedledum;
     Circuit circuit;
 
-    WireRef qubit = circuit.create_qubit();
-    WireRef cbit = circuit.create_cbit();
-    CHECK(qubit.kind() == Wire::Kind::quantum);
-    CHECK(cbit.kind() == Wire::Kind::classical);
+    Cbit cbit = circuit.create_cbit();
+    Qubit qubit = circuit.create_qubit();
+    CHECK(circuit.num_cbits() == 1u);
+    CHECK(circuit.num_qubits() == 1u);
+    CHECK(static_cast<uint32_t>(cbit) == static_cast<uint32_t>(qubit));
+    // CHECK(qubit.kind() == Wire::Kind::quantum);
+    // CHECK(cbit.kind() == Wire::Kind::classical);
 }
 

--- a/test/IR/Instruction.cpp
+++ b/test/IR/Instruction.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Check single-target, one-qubit adjointness", "[instruction][ir]")
 {
     using namespace tweedledum;
     Circuit circuit;
-    WireRef q0 = circuit.create_qubit();
+    Qubit q0 = circuit.create_qubit();
     circuit.apply_operator(Op::H(), {q0});
     circuit.apply_operator(Op::P(sym_angle::pi_quarter), {q0});
     circuit.apply_operator(Op::P(sym_angle::pi_half), {q0});
@@ -40,7 +40,7 @@ TEST_CASE("Check single-target, one-qubit adjointness", "[instruction][ir]")
         circuit.foreach_instruction([&adjoints](Instruction const& inst) {
             std::optional<Operator> adj = inst.adjoint();
             REQUIRE(adj);
-            adjoints.apply_operator(*adj, inst.wires());
+            adjoints.apply_operator(*adj, inst.qubits());
         });
         REQUIRE(circuit.size() == adjoints.size());
 
@@ -67,7 +67,7 @@ TEST_CASE("Check single-target, one-qubit adjointness", "[instruction][ir]")
         // Create a circuit with adjoints but on other qubits
         Circuit non_adjoints;
         non_adjoints.create_qubit();
-        WireRef q1 = non_adjoints.create_qubit();
+        Qubit q1 = non_adjoints.create_qubit();
         circuit.foreach_instruction([&non_adjoints, q1](Instruction const& inst) {
             std::optional<Operator> adj = inst.adjoint();
             non_adjoints.apply_operator(*adj, {q1});
@@ -94,8 +94,8 @@ TEST_CASE("Check single-target, two-qubit adjointness", "[instruction][ir]")
 {
     using namespace tweedledum;
     Circuit circuit;
-    WireRef q0 = circuit.create_qubit();
-    WireRef q1 = circuit.create_qubit();
+    Qubit q0 = circuit.create_qubit();
+    Qubit q1 = circuit.create_qubit();
     circuit.apply_operator(Op::H(), {q0});
     circuit.apply_operator(Op::P(sym_angle::pi_quarter), {q0, q1});
     circuit.apply_operator(Op::P(sym_angle::pi_half), {q0, q1});
@@ -123,7 +123,7 @@ TEST_CASE("Check single-target, two-qubit adjointness", "[instruction][ir]")
         circuit.foreach_instruction([&adjoints](Instruction const& inst) {
             std::optional<Operator> adj = inst.adjoint();
             REQUIRE(adj);
-            adjoints.apply_operator(*adj, inst.wires());
+            adjoints.apply_operator(*adj, inst.qubits());
         });
         REQUIRE(circuit.size() == adjoints.size());
 
@@ -177,8 +177,8 @@ TEST_CASE("Check two-target, two-qubit adjointness", "[instruction][ir]")
 {
     using namespace tweedledum;
     Circuit circuit;
-    WireRef q0 = circuit.create_qubit();
-    WireRef q1 = circuit.create_qubit();
+    Qubit q0 = circuit.create_qubit();
+    Qubit q1 = circuit.create_qubit();
     circuit.apply_operator(Op::Rxx(sym_angle::pi_quarter), {q0, q1});
     circuit.apply_operator(Op::Rxx(sym_angle::pi_half), {q0, q1});
     circuit.apply_operator(Op::Rxx(sym_angle::pi), {q0, q1});
@@ -198,7 +198,7 @@ TEST_CASE("Check two-target, two-qubit adjointness", "[instruction][ir]")
         circuit.foreach_instruction([&adjoints](Instruction const& inst) {
             std::optional<Operator> adj = inst.adjoint();
             REQUIRE(adj);
-            adjoints.apply_operator(*adj, inst.wires());
+            adjoints.apply_operator(*adj, inst.qubits());
         });
         REQUIRE(circuit.size() == adjoints.size());
 

--- a/test/Passes/Decomposition/barenco_decomp.cpp
+++ b/test/Passes/Decomposition/barenco_decomp.cpp
@@ -44,7 +44,7 @@ TEST_CASE("Trivial clean ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled X") {
         for (uint32_t i = 4u; i <= 9; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
             original.apply_operator(Op::X(), qubits);
@@ -56,7 +56,7 @@ TEST_CASE("Trivial clean ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled Y") {
         for (uint32_t i = 1u; i <= 9; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
             original.apply_operator(Op::Y(), qubits);
@@ -68,7 +68,7 @@ TEST_CASE("Trivial clean ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled Z") {
         for (uint32_t i = 1u; i <= 9; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
             original.apply_operator(Op::Z(), qubits);
@@ -89,7 +89,7 @@ TEST_CASE("Trivial dirty ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled X") {
         for (uint32_t i = 4u; i <= 9; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
 
@@ -104,7 +104,7 @@ TEST_CASE("Trivial dirty ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled Y") {
         for (uint32_t i = 1u; i <= 9; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
 
@@ -119,7 +119,7 @@ TEST_CASE("Trivial dirty ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled Z") {
         for (uint32_t i = 1u; i <= 9; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
 
@@ -141,7 +141,7 @@ TEST_CASE("Trivial clean V ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled X") {
         for (uint32_t i = 4u; i <= 7; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
 
@@ -154,7 +154,7 @@ TEST_CASE("Trivial clean V ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled Y") {
         for (uint32_t i = 4u; i <= 7; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
 
@@ -167,7 +167,7 @@ TEST_CASE("Trivial clean V ancilla barenco decomp", "[barenco_decomp][decomp]")
     SECTION("(Mutiple) controlled Z") {
         for (uint32_t i = 4u; i <= 7; ++i) {
             Circuit original;
-            std::vector<WireRef> qubits(i, WireRef::invalid());
+            std::vector<Qubit> qubits(i, Qubit::invalid());
             std::generate(qubits.begin(), qubits.end(),
             [&]() { return original.create_qubit(); });
 

--- a/test/Passes/Decomposition/euler_decomp.cpp
+++ b/test/Passes/Decomposition/euler_decomp.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Euler decomp test cases", "[euler_decomp][decomp]")
     using namespace tweedledum;
     bool const upto_global_phase = true;
     Circuit original;
-    WireRef q0 = original.create_qubit();
+    Qubit q0 = original.create_qubit();
     UMatrix2 matrix = Op::H().matrix();
     original.apply_operator(Op::Unitary(matrix), {q0});
 
@@ -45,7 +45,7 @@ TEST_CASE("Euler decomp test cases", "[euler_decomp][decomp]")
     double phi = 0.7;
     for (uint32_t i = 0; i < 22u; ++i) {
         Circuit original;
-        WireRef q0 = original.create_qubit();
+        Qubit q0 = original.create_qubit();
         UMatrix2 matrix = create_matrix(smallest * std::pow(factor, i), phi, lambda);
         original.apply_operator(Op::Unitary(matrix), {q0});
         Circuit decomposed = euler_decomp(original);

--- a/test/Passes/Optimization/phase_folding.cpp
+++ b/test/Passes/Optimization/phase_folding.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Trivial phase folding", "[phase_folding][optimization]")
     using namespace tweedledum;
     SECTION("Trivial 1 qubit") {
         Circuit circuit;
-        WireRef q0 = circuit.create_qubit();
+        Qubit q0 = circuit.create_qubit();
         circuit.apply_operator(Op::T(), {q0});
         circuit.apply_operator(Op::Tdg(), {q0});
         
@@ -29,8 +29,8 @@ TEST_CASE("Trivial phase folding", "[phase_folding][optimization]")
     }
     SECTION("Trivial 2 qubit swap") {
         Circuit circuit;
-        WireRef q0 = circuit.create_qubit();
-        WireRef q1 = circuit.create_qubit();
+        Qubit q0 = circuit.create_qubit();
+        Qubit q1 = circuit.create_qubit();
         circuit.apply_operator(Op::T(), {q0});
         circuit.apply_operator(Op::Swap(), {q1, q0});
         circuit.apply_operator(Op::Tdg(), {q1});

--- a/test/Passes/Simulation/simulate_classically.cpp
+++ b/test/Passes/Simulation/simulate_classically.cpp
@@ -16,9 +16,9 @@ TEST_CASE("Simulate reversible circuit", "[simulate_classically]")
 {
     using namespace tweedledum;
     Circuit circuit;
-    WireRef q0 = circuit.create_qubit();
-    WireRef q1 = circuit.create_qubit();
-    WireRef q2 = circuit.create_qubit();
+    Qubit q0 = circuit.create_qubit();
+    Qubit q1 = circuit.create_qubit();
+    Qubit q2 = circuit.create_qubit();
 
     SECTION("Empty circuit")
     {

--- a/test/Passes/Synthesis/decomp_synth.cpp
+++ b/test/Passes/Synthesis/decomp_synth.cpp
@@ -13,7 +13,7 @@
 #include <kitty/kitty.hpp>
 
 // DBS = Decomposition-based synthesis
-TEST_CASE("Synthesize a permutation using DBS", "[decomp-based][synth]")
+TEST_CASE("Synthesize a permutation using DBS", "[decomp_synth][synth]")
 {
     using namespace tweedledum;
     SECTION("Prime 3") {

--- a/test/Passes/Synthesis/diagonal_synth.cpp
+++ b/test/Passes/Synthesis/diagonal_synth.cpp
@@ -21,9 +21,9 @@ TEST_CASE("Trivial cases for diagonal_synth", "[diagonal_synth][synth]")
     nlohmann::json config;
     SECTION("Double-control Z") {
         Circuit expected;
-        WireRef q0 = expected.create_qubit();
-        WireRef q1 = expected.create_qubit();
-        WireRef q2 = expected.create_qubit();
+        Qubit q0 = expected.create_qubit();
+        Qubit q1 = expected.create_qubit();
+        Qubit q2 = expected.create_qubit();
         expected.apply_operator(Op::P(sym_angle::pi), {q1, q2, q0});
 
         std::vector<Angle> angles(7, sym_angle::zero);
@@ -33,9 +33,9 @@ TEST_CASE("Trivial cases for diagonal_synth", "[diagonal_synth][synth]")
     }
     SECTION("Double-control Rx ~ CX") {
         Circuit expected;
-        WireRef q0 = expected.create_qubit();
-        WireRef q1 = expected.create_qubit();
-        WireRef q2 = expected.create_qubit();
+        Qubit q0 = expected.create_qubit();
+        Qubit q1 = expected.create_qubit();
+        Qubit q2 = expected.create_qubit();
         expected.apply_operator(Op::Rx(sym_angle::pi), {q1, q2, q0});
 
         std::vector<Angle> angles(6, sym_angle::zero);

--- a/test/Passes/Synthesis/diagonal_synth.cpp
+++ b/test/Passes/Synthesis/diagonal_synth.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Trivial cases for diagonal_synth", "[diagonal_synth][synth]")
         synthesized.create_qubit();
         synthesized.create_qubit();
         synthesized.apply_operator(Op::H(), {q0});
-        diagonal_synth(synthesized, {q1, q2, q0}, angles, config);
+        diagonal_synth(synthesized, {q1, q2, q0}, {}, angles, config);
         synthesized.apply_operator(Op::H(), {q0});
         CHECK(check_unitary(expected, synthesized));
     }

--- a/test/Passes/Synthesis/gray_synth.cpp
+++ b/test/Passes/Synthesis/gray_synth.cpp
@@ -40,10 +40,10 @@ TEST_CASE("Trivial cases for gray_synth", "[gray_synth][synth]")
         // The example in the paper is wrong! :( 
         // (it took me a while to figure it out)
         Circuit expected;
-        WireRef q0 = expected.create_qubit();
-        WireRef q1 = expected.create_qubit();
-        WireRef q2 = expected.create_qubit();
-        WireRef q3 = expected.create_qubit();
+        Qubit q0 = expected.create_qubit();
+        Qubit q1 = expected.create_qubit();
+        Qubit q2 = expected.create_qubit();
+        Qubit q3 = expected.create_qubit();
         expected.apply_operator(Op::T(), {q0});
         expected.apply_operator(Op::X(), {q2, q1});
         expected.apply_operator(Op::T(), {q1});

--- a/test/Passes/Synthesis/linear_synth.cpp
+++ b/test/Passes/Synthesis/linear_synth.cpp
@@ -27,9 +27,9 @@ TEST_CASE("Trivial cases for linear_synth", "[linear_synth][synth]")
     Circuit synthesized = linear_synth(linear_trans, config);
 
     Circuit expected;
-    WireRef q0 = expected.create_qubit();
-    WireRef q1 = expected.create_qubit();
-    WireRef q2 = expected.create_qubit();
+    Qubit q0 = expected.create_qubit();
+    Qubit q1 = expected.create_qubit();
+    Qubit q2 = expected.create_qubit();
     expected.apply_operator(Op::X(), {q2, q1});
     expected.apply_operator(Op::X(), {q1, q0});
     CHECK(check_unitary(expected, synthesized));

--- a/test/Passes/Synthesis/spectrum_synth.cpp
+++ b/test/Passes/Synthesis/spectrum_synth.cpp
@@ -24,9 +24,9 @@ TEST_CASE("Trivial cases for spectrum_synth", "[spectrum_synth][synth]")
     CHECK(synthesized.num_qubits() == 3u);
     
     Circuit expected;
-    WireRef q0 = expected.create_qubit();
-    WireRef q1 = expected.create_qubit();
-    WireRef q2 = expected.create_qubit();
+    Qubit q0 = expected.create_qubit();
+    Qubit q1 = expected.create_qubit();
+    Qubit q2 = expected.create_qubit();
     expected.apply_operator(Op::X(), {q0, q1, q2});
     CHECK(check_unitary(expected, synthesized));
 }

--- a/test/Passes/Synthesis/xag_synth.cpp
+++ b/test/Passes/Synthesis/xag_synth.cpp
@@ -37,8 +37,8 @@ mockturtle::xag_network to_xag_network(
     }
     circuit.foreach_instruction([&](Instruction const& inst) {
         std::vector<Signal> signals;
-        inst.foreach_wire([&](WireRef w) {
-            signals.push_back(to_signal[w.uid()] ^ w.is_complemented());
+        inst.foreach_qubit([&](Qubit w) {
+            signals.push_back(to_signal[w.uid()] ^ (w.polarity() == Qubit::Polarity::negative));
         });
         if (inst.is_a<Op::Parity>()) {
             to_signal[inst.target().uid()] = network.create_nary_xor(signals);

--- a/test/base/base.cpp
+++ b/test/base/base.cpp
@@ -16,9 +16,9 @@ TEST_CASE("Toffoli gate", "[base]")
     using namespace tweedledum;
 
     Circuit high_level;
-    WireRef q0 = high_level.create_qubit();
-    WireRef q1 = high_level.create_qubit();
-    WireRef q2 = high_level.create_qubit();
+    Qubit q0 = high_level.create_qubit();
+    Qubit q1 = high_level.create_qubit();
+    Qubit q2 = high_level.create_qubit();
     high_level.apply_operator(Op::X(), {q0, q1, q2});
 
     SECTION("Identified Phases") {


### PR DESCRIPTION
This PR refactor how `tweedledum` handle wires. Instead of having one `Wire` type that could be either `quantum` or `classical`, I separated them into two new types: `Qubit` and `Cbit`. 