### PR TITLE
Simple parser for TFC file format.

### DIFF
--- a/include/tweedledum/Parser/tfc.h
+++ b/include/tweedledum/Parser/tfc.h
@@ -1,0 +1,17 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../IR/Circuit.h"
+
+#include <string_view>
+
+namespace tweedledum::tfc {
+
+Circuit parse_source_file(std::string_view path);
+
+Circuit parse_source_buffer(std::string_view buffer);
+
+} // namespace tweedledum::tfc

--- a/python/tweedledum/ir/circuit.cpp
+++ b/python/tweedledum/ir/circuit.cpp
@@ -7,6 +7,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 #include <tweedledum/Parser/qasm.h>
+#include <tweedledum/Parser/tfc.h>
 #include <tweedledum/Operators/All.h>
 #include <tweedledum/Utils/Visualization/string_utf8.h>
 
@@ -18,6 +19,7 @@ void init_Circuit(pybind11::module& module)
     py::class_<Circuit>(module, "Circuit")
         .def_static("from_qasm_file", &qasm::parse_source_file)
         .def_static("from_qasm_string", &qasm::parse_source_buffer)
+        .def_static("from_tfc_file", &tfc::parse_source_file)
         .def(py::init<>())
         // Properties
         .def("num_ancillae", &Circuit::num_ancillae)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/Parser/QASM/Lexer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Parser/QASM/Parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Parser/qasm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Parser/tfc.cpp
     # Passes
     ${CMAKE_CURRENT_SOURCE_DIR}/Passes/Decomposition/barenco_decomp.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Passes/Decomposition/bridge_decomp.cpp

--- a/src/Parser/tfc.cpp
+++ b/src/Parser/tfc.cpp
@@ -1,0 +1,126 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#include "tweedledum/IR/Circuit.h"
+#include "tweedledum/IR/Qubit.h"
+#include "tweedledum/Operators/Standard/Swap.h"
+#include "tweedledum/Operators/Standard/X.h"
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace tweedledum::tfc {
+namespace {
+
+inline void left_trim(std::string& str, char const* chars = " \t\n\v\f\r")
+{
+    if (str.empty()) {
+        return;
+    }
+    std::size_t pos = str.find_first_not_of(chars);
+    if (pos == std::string::npos) {
+        str.clear();
+    } else if (pos > 0) {
+        str = str.substr(pos, std::string::npos);
+    }
+}
+
+inline std::vector<std::string> split(std::string const& line)
+{
+    std::vector<std::string> slipt_string;
+
+    std::istringstream iss(line);
+    std::for_each(std::istream_iterator<std::string>(iss),
+      std::istream_iterator<std::string>(), [&slipt_string](auto const& str) {
+          std::size_t begin = 0;
+          std::size_t end = str.find(',', begin);
+          if (end == std::string::npos) {
+              slipt_string.emplace_back(str);
+              return;
+          }
+          while (end != std::string::npos) {
+              std::string substr = str.substr(begin, end - begin);
+              left_trim(substr);
+              slipt_string.emplace_back(substr);
+              begin = end + 1;
+              end = str.find(',', begin);
+          }
+          if (begin < str.size()) {
+            slipt_string.emplace_back(str.substr(begin));
+          }
+      });
+    return slipt_string;
+}
+
+Circuit parse_stream(std::istream& buffer)
+{
+    Circuit circuit;
+    std::unordered_map<std::string, Qubit> qubits;
+    std::string line;
+
+    // Parser header directives
+    while (buffer.peek() == '.' || buffer.peek() == '#') {
+        if (buffer.peek() == '#') {
+            std::getline(buffer, line);
+            continue;
+        }
+        std::getline(buffer, line, ' ');
+        if (line[1] == 'v') {
+            std::getline(buffer, line);
+            auto labels = split(line);
+            for (auto const& label : labels) {
+                qubits.emplace(label, circuit.create_qubit(label));
+            }
+        } else {
+            // Ignore unknown directive line.
+            std::getline(buffer, line);
+        }
+    }
+
+    while (std::getline(buffer, line)) {
+        left_trim(line);
+        if (line.empty() || line.at(0) == '#') {
+            continue;
+        }
+        auto entries = split(line);
+        if (entries.at(0) == "BEGIN" || entries.at(0) == "END") {
+            continue;
+        }
+        Operator op = Op::X();
+        if (entries.at(0).at(0) == 'f') {
+            op = Op::Swap();
+        }
+        std::vector<Qubit> op_qubits;
+        std::for_each(
+          entries.begin() + 1, entries.end(), [&](std::string const& label) {
+              op_qubits.push_back(qubits.at(label));
+          });
+        circuit.apply_operator(op, op_qubits);
+    }
+    return circuit;
+}
+
+} // namespace
+
+Circuit parse_source_buffer(std::string_view buffer)
+{
+    std::istringstream iss{std::string(buffer)};
+    return parse_stream(iss);
+}
+
+Circuit parse_source_file(std::string_view path)
+{
+    std::ifstream stream{std::string(path)};
+    assert(stream.is_open());
+    Circuit circuit = parse_stream(stream);
+    stream.close();
+    return circuit;
+}
+
+} // namespace tweedledum::tfc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(tweedledum_tests_files
     ${CMAKE_CURRENT_SOURCE_DIR}/IR/Instruction.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Operators/Unitary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Parser/qasm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Parser/tfc.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Passes/Analysis/compute_alap_layers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Passes/Analysis/compute_asap_layers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Passes/Analysis/compute_critical_paths.cpp

--- a/tests/Parser/tfc.cpp
+++ b/tests/Parser/tfc.cpp
@@ -1,0 +1,58 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#include "tweedledum/Parser/tfc.h"
+#include "tweedledum/Operators/Standard/Swap.h"
+#include "tweedledum/Operators/Standard/X.h"
+
+#include "../check_unitary.h"
+
+#include <catch.hpp>
+
+TEST_CASE("TFC Parsing", "[tfc][parser]")
+{
+    using namespace tweedledum;
+    SECTION("Empty buffer")
+    {
+        std::string tfc = "";
+        Circuit parsed = tfc::parse_source_buffer(tfc);
+        CHECK(parsed.size() == 0u);
+    }
+    SECTION("Circuit without instructions")
+    {
+        std::string tfc = "# A comment.\n"
+                          ".v a,b c1, d5\n";
+        Circuit parsed = tfc::parse_source_buffer(tfc);
+        CHECK(parsed.size() == 0u);
+        CHECK(parsed.num_qubits() == 4u);
+        CHECK(parsed.num_cbits() == 0u);
+    }
+    SECTION("Circuit without instructions")
+    {
+        std::string tfc = "# A comment.\n"
+                          ".v a,b c1, d5\n"
+                          "BEGIN\n"
+                          "t1 a\n"
+                          "\n"
+                          " f2 a, b\n"
+                          "# Another comment\n"
+                          "t4 a,b c1, d5\n"
+                          "f3 a,b,d5\n"
+                          "END\n";
+        Circuit parsed = tfc::parse_source_buffer(tfc);
+        CHECK(parsed.size() == 4u);
+        CHECK(parsed.num_qubits() == 4u);
+        CHECK(parsed.num_cbits() == 0u);
+        Circuit expected;
+        Qubit a = expected.create_qubit();
+        Qubit b = expected.create_qubit();
+        Qubit c1 = expected.create_qubit();
+        Qubit d5 = expected.create_qubit();
+        expected.apply_operator(Op::X(), {a});
+        expected.apply_operator(Op::Swap(), {a, b});
+        expected.apply_operator(Op::X(), {a, b, c1, d5});
+        expected.apply_operator(Op::Swap(), {a, b, d5});
+        CHECK(check_unitary(expected, parsed));
+    }
+}


### PR DESCRIPTION
### Description
This is a simple file format used in the ["Reversible Logic Synthesis
Benchmarks Page."](http://webhome.cs.uvic.ca/~dmaslov/mach-read.html)


### Suggested changelog entry:
<!-- Fill in the below block with the expected RestructuredText entry.
     Delete if no entry needed; -->

```rst
TFC parser
```

<!-- If the upgrade guide needs updating, note that here too -->
