### PR TITLE
Add travis job for non-x86 linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+---
+notifications:
+  email: false
+os: linux
+language: python
+cache:
+  pip: true
+  cargo: true
+dist: bionic
+install:
+  - pip install -U twine importlib-metadata keyring cibuildwheel==1.11.1
+stages:
+  - name: deploy
+    if: tag IS present
+
+jobs:
+  include:
+    - stage: deploy
+      arch: arm64
+      python: 3.7
+      services:
+        - docker
+      env:
+        - CIBW_TEST_COMMAND="python -m unittest discover -s {project}/python/test/ -t {project}"
+        - CMAKE_BUILD_PARALLEL_LEVEL=2
+        - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
+      script:
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*
+    - stage: deploy
+      arch: ppc64le
+      python: 3.7
+      services:
+        - docker
+      env:
+        - CIBW_TEST_COMMAND="python -m unittest discover -s {project}/python/test/ -t {project}"
+        - CMAKE_BUILD_PARALLEL_LEVEL=2
+        - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
+      script:
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*
+    - stage: deploy
+      arch: s390x
+      python: 3.7
+      services:
+        - docker
+      env:
+        - CIBW_TEST_COMMAND="python -m unittest discover -s {project}/python/test/ -t {project}"
+        - CMAKE_BUILD_PARALLEL_LEVEL=2
+        - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
+        - CIBW_BEFORE_ALL="yum install -y wget && {package}/tools/install_rust_no_rustup.sh"
+        - CIBW_BEFORE_BUILD="pip install -U setuptools-rust"
+      script:
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*
+


### PR DESCRIPTION
<!-- Thanks for helping us improve tweedledum! -->

### Description

This commit adds a travis ci configuration to leverage travis for
building non-x86 precompiled linux binaries for pypi. It will require enabling
travis CI on the repo before we can test this.

<!-- Include relevant issues here, describe what changed and why -->

### Suggested changelog entry:
<!-- Fill in the below block with the expected RestructuredText entry.
     Delete if no entry needed; -->

```rst
Added binary wheel builds for aarch64, ppc64le, and s390x linux.
```

<!-- If the upgrade guide needs updating, note that here too -->
