### PR TITLE
Expr variables order

### DIFF
--- a/python/test/test_BoolFunction.py
+++ b/python/test/test_BoolFunction.py
@@ -1,26 +1,27 @@
-#-------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Part of Tweedledum Project.  This file is distributed under the MIT License.
 # See accompanying file /LICENSE for details.
-#-------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 import unittest
 
 from tweedledum.bool_function_compiler import BitVec, BoolFunction
 from python.test import examples
+
 
 class TestBoolFunction(unittest.TestCase):
     def test_constant_3bit(self):
         function = BoolFunction(examples.constant_3bit)
         self.assertEqual(function._parameters_signature, [])
         result = examples.constant_3bit()
-        self.assertEqual(result, BitVec(3, '101'))
+        self.assertEqual(result, BitVec(3, "101"))
 
     def test_identity(self):
         function = BoolFunction(examples.identity)
         self.assertEqual(function._parameters_signature, [(type(BitVec(1)), 1)])
-        result = examples.identity(BitVec(1, '0'))
-        self.assertEqual(result, BitVec(1, '0'))
-        result = examples.identity(BitVec(1, '1'))
-        self.assertEqual(result, BitVec(1, '1'))
+        result = examples.identity(BitVec(1, "0"))
+        self.assertEqual(result, BitVec(1, "0"))
+        result = examples.identity(BitVec(1, "1"))
+        self.assertEqual(result, BitVec(1, "1"))
 
     def test_identity_2bit(self):
         function = BoolFunction(examples.identity_2bit)
@@ -56,8 +57,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bool_and(self):
         function = BoolFunction(examples.bool_and)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = examples.bool_and(BitVec(1, a), BitVec(1, b))
@@ -66,8 +68,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bit_and(self):
         function = BoolFunction(examples.bit_and)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = examples.bit_and(BitVec(1, a), BitVec(1, b))
@@ -76,8 +79,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bit_and_2bit(self):
         function = BoolFunction(examples.bit_and_2bit)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(2)), 2), (type(BitVec(2)), 2)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(2)), 2), (type(BitVec(2)), 2)]
+        )
         for a in range(4):
             for b in range(4):
                 result = examples.bit_and_2bit(BitVec(2, a), BitVec(2, b))
@@ -86,8 +90,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bool_or(self):
         function = BoolFunction(examples.bool_or)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = examples.bool_or(BitVec(1, a), BitVec(1, b))
@@ -96,8 +101,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bit_or(self):
         function = BoolFunction(examples.bit_or)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = examples.bit_or(BitVec(1, a), BitVec(1, b))
@@ -106,8 +112,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bit_or_2bit(self):
         function = BoolFunction(examples.bit_or_2bit)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(2)), 2), (type(BitVec(2)), 2)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(2)), 2), (type(BitVec(2)), 2)]
+        )
         for a in range(4):
             for b in range(4):
                 result = examples.bit_or_2bit(BitVec(2, a), BitVec(2, b))
@@ -116,8 +123,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bit_xor(self):
         function = BoolFunction(examples.bit_xor)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = examples.bit_xor(BitVec(1, a), BitVec(1, b))
@@ -126,8 +134,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bit_xor_2bit(self):
         function = BoolFunction(examples.bit_xor_2bit)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(2)), 2), (type(BitVec(2)), 2)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(2)), 2), (type(BitVec(2)), 2)]
+        )
         for a in range(4):
             for b in range(4):
                 result = examples.bit_xor_2bit(BitVec(2, a), BitVec(2, b))
@@ -136,8 +145,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_eq(self):
         function = BoolFunction(examples.eq)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = examples.eq(BitVec(1, a), BitVec(1, b))
@@ -146,8 +156,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bit_eq_2bit(self):
         function = BoolFunction(examples.eq_2bit)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(2)), 2), (type(BitVec(2)), 2)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(2)), 2), (type(BitVec(2)), 2)]
+        )
         for a in range(4):
             for b in range(4):
                 result = examples.eq_2bit(BitVec(2, a), BitVec(2, b))
@@ -156,8 +167,9 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_ne(self):
         function = BoolFunction(examples.ne)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = examples.ne(BitVec(1, a), BitVec(1, b))
@@ -166,24 +178,26 @@ class TestBoolFunction(unittest.TestCase):
 
     def test_bit_ne_2bit(self):
         function = BoolFunction(examples.ne_2bit)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(2)), 2), (type(BitVec(2)), 2)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(2)), 2), (type(BitVec(2)), 2)]
+        )
         for a in range(4):
             for b in range(4):
                 result = examples.ne_2bit(BitVec(2, a), BitVec(2, b))
                 tmp = BitVec(2, a) != BitVec(2, b)
                 self.assertEqual(result, tmp)
 
+
 class TestBoolFunctionSimulation(unittest.TestCase):
     def test_constant(self):
         function = BoolFunction(examples.constant)
         result = function.simulate()
-        self.assertEqual(result, BitVec(1, '1'))
+        self.assertEqual(result, BitVec(1, "1"))
 
     def test_constant_2bit(self):
         function = BoolFunction(examples.constant_2bit)
         result = function.simulate()
-        self.assertEqual(result, BitVec('10'))
+        self.assertEqual(result, BitVec("10"))
 
     def test_constant_3bit(self):
         function = BoolFunction(examples.constant_3bit)
@@ -193,14 +207,14 @@ class TestBoolFunctionSimulation(unittest.TestCase):
     def test_constant_4bit(self):
         function = BoolFunction(examples.constant_4bit)
         result = function.simulate()
-        self.assertEqual(result, BitVec('0000'))
+        self.assertEqual(result, BitVec("0000"))
 
     def test_identity(self):
         function = BoolFunction(examples.identity)
-        result = function.simulate(BitVec(1, '0'))
-        self.assertEqual(result, BitVec(1, '0'))
-        result = function.simulate(BitVec(1, '1'))
-        self.assertEqual(result, BitVec(1, '1'))
+        result = function.simulate(BitVec(1, "0"))
+        self.assertEqual(result, BitVec(1, "0"))
+        result = function.simulate(BitVec(1, "1"))
+        self.assertEqual(result, BitVec(1, "1"))
 
     def test_identity_2bit(self):
         function = BoolFunction(examples.identity_2bit)
@@ -208,7 +222,7 @@ class TestBoolFunctionSimulation(unittest.TestCase):
             tmp = BitVec(2, a)
             result = function.simulate(tmp)
             self.assertEqual(result, tmp)
-    
+
     def test_identity_not(self):
         function = BoolFunction(examples.identity_not)
         for a in range(4):
@@ -303,8 +317,9 @@ class TestBoolFunctionSimulation(unittest.TestCase):
 
     def test_eq(self):
         function = BoolFunction(examples.eq)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = function.simulate(BitVec(1, a), BitVec(1, b))
@@ -313,8 +328,9 @@ class TestBoolFunctionSimulation(unittest.TestCase):
 
     def test_bit_eq_2bit(self):
         function = BoolFunction(examples.eq_2bit)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(2)), 2), (type(BitVec(2)), 2)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(2)), 2), (type(BitVec(2)), 2)]
+        )
         for a in range(4):
             for b in range(4):
                 result = function.simulate(BitVec(2, a), BitVec(2, b))
@@ -323,8 +339,9 @@ class TestBoolFunctionSimulation(unittest.TestCase):
 
     def test_ne(self):
         function = BoolFunction(examples.ne)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(1)), 1), (type(BitVec(1)), 1)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(1)), 1), (type(BitVec(1)), 1)]
+        )
         for a in range(2):
             for b in range(2):
                 result = function.simulate(BitVec(1, a), BitVec(1, b))
@@ -333,13 +350,15 @@ class TestBoolFunctionSimulation(unittest.TestCase):
 
     def test_bit_ne_2bit(self):
         function = BoolFunction(examples.ne_2bit)
-        self.assertEqual(function._parameters_signature,
-                         [(type(BitVec(2)), 2), (type(BitVec(2)), 2)])
+        self.assertEqual(
+            function._parameters_signature, [(type(BitVec(2)), 2), (type(BitVec(2)), 2)]
+        )
         for a in range(4):
             for b in range(4):
                 result = function.simulate(BitVec(2, a), BitVec(2, b))
                 tmp = BitVec(2, a) != BitVec(2, b)
                 self.assertEqual(result, tmp)
+
 
 class TestBoolFunctionFullSimulation(unittest.TestCase):
     def test_identity(self):
@@ -349,12 +368,12 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 1)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '10')
-        
-        result = function.simulate(BitVec(1, '0'))
-        self.assertEqual(result, BitVec(1, '0'))
-        result = function.simulate(BitVec(1, '1'))
-        self.assertEqual(result, BitVec(1, '1'))
+        self.assertEqual(str(function.truth_table(output_bit=0)), "10")
+
+        result = function.simulate(BitVec(1, "0"))
+        self.assertEqual(result, BitVec(1, "0"))
+        result = function.simulate(BitVec(1, "1"))
+        self.assertEqual(result, BitVec(1, "1"))
 
     def test_identity_2bit(self):
         function = BoolFunction(examples.identity_2bit)
@@ -363,8 +382,8 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
         self.assertEqual(function.num_output_bits(), 2)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '1010')
-        self.assertEqual(str(function.truth_table(output_bit=1)), '1100')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "1010")
+        self.assertEqual(str(function.truth_table(output_bit=1)), "1100")
         for a in range(4):
             tmp = BitVec(2, a)
             result = function.simulate(tmp)
@@ -377,7 +396,7 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 1)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '01')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "01")
         for a in range(2):
             tmp = BitVec(1, a)
             result = function.simulate(tmp)
@@ -390,8 +409,8 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
         self.assertEqual(function.num_output_bits(), 2)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '0101')
-        self.assertEqual(str(function.truth_table(output_bit=1)), '0011')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "0101")
+        self.assertEqual(str(function.truth_table(output_bit=1)), "0011")
         for a in range(4):
             tmp = BitVec(2, a)
             result = function.simulate(tmp)
@@ -404,7 +423,7 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '1000')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "1000")
         for a in range(2):
             for b in range(2):
                 result = function.simulate(BitVec(1, a), BitVec(1, b))
@@ -418,8 +437,8 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 4)
         self.assertEqual(function.num_output_bits(), 2)
-        output0 = BitVec(16, 0xaaaa) & BitVec(16, 0xf0f0)
-        output1 = BitVec(16, 0xcccc) & BitVec(16, 0xff00)
+        output0 = BitVec(16, 0xAAAA) & BitVec(16, 0xF0F0)
+        output1 = BitVec(16, 0xCCCC) & BitVec(16, 0xFF00)
         self.assertEqual(str(function.truth_table(output_bit=0)), str(output0))
         self.assertEqual(str(function.truth_table(output_bit=1)), str(output1))
         for a in range(4):
@@ -435,7 +454,7 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '1110')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "1110")
         for a in range(2):
             for b in range(2):
                 result = function.simulate(BitVec(1, a), BitVec(1, b))
@@ -449,8 +468,8 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 4)
         self.assertEqual(function.num_output_bits(), 2)
-        output0 = BitVec(16, 0xaaaa) | BitVec(16, 0xf0f0)
-        output1 = BitVec(16, 0xcccc) | BitVec(16, 0xff00)
+        output0 = BitVec(16, 0xAAAA) | BitVec(16, 0xF0F0)
+        output1 = BitVec(16, 0xCCCC) | BitVec(16, 0xFF00)
         self.assertEqual(str(function.truth_table(output_bit=0)), str(output0))
         self.assertEqual(str(function.truth_table(output_bit=1)), str(output1))
         for a in range(4):
@@ -466,8 +485,8 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 4)
         self.assertEqual(function.num_output_bits(), 2)
-        output0 = BitVec(16, 0xaaaa) ^ BitVec(16, 0xf0f0)
-        output1 = BitVec(16, 0xcccc) ^ BitVec(16, 0xff00)
+        output0 = BitVec(16, 0xAAAA) ^ BitVec(16, 0xF0F0)
+        output1 = BitVec(16, 0xCCCC) ^ BitVec(16, 0xFF00)
         self.assertEqual(str(function.truth_table(output_bit=0)), str(output0))
         self.assertEqual(str(function.truth_table(output_bit=1)), str(output1))
         for a in range(4):
@@ -475,6 +494,7 @@ class TestBoolFunctionFullSimulation(unittest.TestCase):
                 result = function.simulate(BitVec(2, a), BitVec(2, b))
                 tmp = BitVec(2, a) ^ BitVec(2, b)
                 self.assertEqual(result, tmp)
+
 
 class TestBoolFunctionExpressionConstructor(unittest.TestCase):
     def test_identity(self):
@@ -484,7 +504,7 @@ class TestBoolFunctionExpressionConstructor(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 1)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '10')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "10")
 
     def test_not(self):
         function = BoolFunction.from_expression("~x")
@@ -493,7 +513,7 @@ class TestBoolFunctionExpressionConstructor(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 1)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '01')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "01")
 
     def test_and(self):
         function = BoolFunction.from_expression("x & b")
@@ -502,7 +522,7 @@ class TestBoolFunctionExpressionConstructor(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '1000')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "1000")
 
     def test_or(self):
         function = BoolFunction.from_expression("x | b")
@@ -511,7 +531,7 @@ class TestBoolFunctionExpressionConstructor(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '1110')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "1110")
 
     def test_xor(self):
         function = BoolFunction.from_expression("x ^ b")
@@ -520,7 +540,7 @@ class TestBoolFunctionExpressionConstructor(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '0110')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "0110")
 
     def test_de_morgan(self):
         function = BoolFunction.from_expression("~(~(x0 | x1) ^ (~x0 & ~x1))")
@@ -529,22 +549,23 @@ class TestBoolFunctionExpressionConstructor(unittest.TestCase):
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
         self.assertEqual(function.num_output_bits(), 1)
-        self.assertEqual(str(function.truth_table(output_bit=0)), '1111')
+        self.assertEqual(str(function.truth_table(output_bit=0)), "1111")
+
 
 class TestBoolFunctionTTConstructor(unittest.TestCase):
     def test_identity(self):
-        function = BoolFunction.from_truth_table('10')
+        function = BoolFunction.from_truth_table("10")
         self.assertEqual(function.num_inputs(), 1)
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 1)
         self.assertEqual(function.num_output_bits(), 1)
-        result = function.simulate(BitVec(1, '0'))
-        self.assertEqual(result, BitVec(1, '0'))
-        result = function.simulate(BitVec(1, '1'))
-        self.assertEqual(result, BitVec(1, '1'))
+        result = function.simulate(BitVec(1, "0"))
+        self.assertEqual(result, BitVec(1, "0"))
+        result = function.simulate(BitVec(1, "1"))
+        self.assertEqual(result, BitVec(1, "1"))
 
     def test_identity_2bit(self):
-        function = BoolFunction.from_truth_table(['1010', '1100'])
+        function = BoolFunction.from_truth_table(["1010", "1100"])
         self.assertEqual(function.num_inputs(), 2)
         self.assertEqual(function.num_outputs(), 2)
         self.assertEqual(function.num_input_bits(), 2)
@@ -555,7 +576,7 @@ class TestBoolFunctionTTConstructor(unittest.TestCase):
             self.assertEqual(result, (tmp[0], tmp[1]))
 
     def test_not(self):
-        function = BoolFunction.from_truth_table('01')
+        function = BoolFunction.from_truth_table("01")
         self.assertEqual(function.num_inputs(), 1)
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 1)
@@ -566,7 +587,7 @@ class TestBoolFunctionTTConstructor(unittest.TestCase):
             self.assertEqual(result, ~tmp)
 
     def test_not_2bit(self):
-        function = BoolFunction.from_truth_table(['0101', '0011'])
+        function = BoolFunction.from_truth_table(["0101", "0011"])
         self.assertEqual(function.num_inputs(), 2)
         self.assertEqual(function.num_outputs(), 2)
         self.assertEqual(function.num_input_bits(), 2)
@@ -577,7 +598,7 @@ class TestBoolFunctionTTConstructor(unittest.TestCase):
             self.assertEqual(result, (~tmp[0], ~tmp[1]))
 
     def test_and(self):
-        function = BoolFunction.from_truth_table('1000')
+        function = BoolFunction.from_truth_table("1000")
         self.assertEqual(function.num_inputs(), 2)
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
@@ -589,8 +610,9 @@ class TestBoolFunctionTTConstructor(unittest.TestCase):
                 self.assertEqual(result, tmp)
 
     def test_and_2bit(self):
-        function = BoolFunction.from_truth_table(['1010000010100000', 
-                                                  '1100110000000000'])
+        function = BoolFunction.from_truth_table(
+            ["1010000010100000", "1100110000000000"]
+        )
         self.assertEqual(function.num_inputs(), 4)
         self.assertEqual(function.num_outputs(), 2)
         self.assertEqual(function.num_input_bits(), 4)
@@ -605,7 +627,7 @@ class TestBoolFunctionTTConstructor(unittest.TestCase):
 
     def test_or(self):
         function = BoolFunction(examples.bool_and)
-        function = BoolFunction.from_truth_table('1110')
+        function = BoolFunction.from_truth_table("1110")
         self.assertEqual(function.num_inputs(), 2)
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
@@ -617,8 +639,9 @@ class TestBoolFunctionTTConstructor(unittest.TestCase):
                 self.assertEqual(result, tmp)
 
     def test_or_2bit(self):
-        function = BoolFunction.from_truth_table(['1111101011111010', 
-                                                  '1111111111001100'])
+        function = BoolFunction.from_truth_table(
+            ["1111101011111010", "1111111111001100"]
+        )
         self.assertEqual(function.num_inputs(), 4)
         self.assertEqual(function.num_outputs(), 2)
         self.assertEqual(function.num_input_bits(), 4)
@@ -633,7 +656,7 @@ class TestBoolFunctionTTConstructor(unittest.TestCase):
 
     def test_xor(self):
         function = BoolFunction(examples.bool_and)
-        function = BoolFunction.from_truth_table('0110')
+        function = BoolFunction.from_truth_table("0110")
         self.assertEqual(function.num_inputs(), 2)
         self.assertEqual(function.num_outputs(), 1)
         self.assertEqual(function.num_input_bits(), 2)
@@ -645,8 +668,9 @@ class TestBoolFunctionTTConstructor(unittest.TestCase):
                 self.assertEqual(result, tmp)
 
     def test_xor_2bit(self):
-        function = BoolFunction.from_truth_table(['0101101001011010', 
-                                                  '0011001111001100'])
+        function = BoolFunction.from_truth_table(
+            ["0101101001011010", "0011001111001100"]
+        )
         self.assertEqual(function.num_inputs(), 4)
         self.assertEqual(function.num_outputs(), 2)
         self.assertEqual(function.num_input_bits(), 4)

--- a/python/test/test_ExpressionParser.py
+++ b/python/test/test_ExpressionParser.py
@@ -1,0 +1,31 @@
+# ------------------------------------------------------------------------------
+# Part of Tweedledum Project.  This file is distributed under the MIT License.
+# See accompanying file /LICENSE for details.
+# ------------------------------------------------------------------------------
+import unittest
+
+from tweedledum.bool_function_compiler.expression_parser import ExpressionParser
+
+
+class TestExpressionParser(unittest.TestCase):
+    def _get_node(self, parser, symbol):
+        _, signals_ = parser._symbol_table[symbol]
+        return parser._logic_network.get_node(signals_[0])
+
+    def test_ordered(self):
+        parser = ExpressionParser(
+            "((A & C) | (B & D)) & ~(C & D)", var_order=["A", "B", "C", "D"]
+        )
+        # Remember that index 0 is the constant!
+        self.assertEqual(self._get_node(parser, "A"), parser._logic_network.pi_at(0))
+        self.assertEqual(self._get_node(parser, "B"), parser._logic_network.pi_at(1))
+        self.assertEqual(self._get_node(parser, "C"), parser._logic_network.pi_at(2))
+        self.assertEqual(self._get_node(parser, "D"), parser._logic_network.pi_at(3))
+
+    def test_unordered(self):
+        parser = ExpressionParser("((A & C) | (B & D)) & ~(C & D)")
+        # Remember that index 0 is the constant!
+        self.assertEqual(self._get_node(parser, "A"), parser._logic_network.pi_at(0))
+        self.assertEqual(self._get_node(parser, "B"), parser._logic_network.pi_at(2))
+        self.assertEqual(self._get_node(parser, "C"), parser._logic_network.pi_at(1))
+        self.assertEqual(self._get_node(parser, "D"), parser._logic_network.pi_at(3))

--- a/python/tweedledum/bool_function_compiler/bool_function.py
+++ b/python/tweedledum/bool_function_compiler/bool_function.py
@@ -118,7 +118,7 @@ class BoolFunction(object):
         return self._truth_table[output_bit]
 
     @classmethod
-    def from_expression(cls, expression: str):
+    def from_expression(cls, expression: str, var_order: list = None):
         """
         Create a BooleanFunction from an arbitrary logical expression.
 
@@ -140,7 +140,7 @@ class BoolFunction(object):
         from .expression_parser import ExpressionParser
 
         function = cls.__new__(cls)
-        parsed_expression = ExpressionParser(expression)
+        parsed_expression = ExpressionParser(expression, var_order)
         function._parameters_signature = parsed_expression._parameters_signature
         function._return_signature = parsed_expression._return_signature
         function._logic_network = parsed_expression._logic_network

--- a/python/tweedledum/bool_function_compiler/bool_function.py
+++ b/python/tweedledum/bool_function_compiler/bool_function.py
@@ -1,9 +1,9 @@
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Part of Tweedledum Project.  This file is distributed under the MIT License.
 # See accompanying file /LICENSE for details.
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 from typing import Union, List
-import functools 
+import functools
 import inspect
 import math
 import string
@@ -14,11 +14,12 @@ from .function_parser import FunctionParser
 from .._tweedledum.classical import TruthTable, create_from_binary_string
 from .._tweedledum import classical
 
+
 class BoolFunction(object):
     """Class to represent a Boolean function
 
     Formally, a Boolean function is a mapping :math:`f : {0, 1}^n \to {0, 1}^m`,
-    where :math:`n`(:math:`m`) is the number of inputs(outputs).  There are 
+    where :math:`n`(:math:`m`) is the number of inputs(outputs).  There are
     many ways to represent/specify a Boolean function.  Here, we use two:
 
     Truth tables:  They are are an explicit and _not compact_ function
@@ -29,13 +30,14 @@ class BoolFunction(object):
 
     Logic network (Xor-And graph, XAG): A logic network is modeled by a directed
         acyclic graph where nodes represent primary inputs and outputs, as well
-        as local functions.  The nodes representing local function as called 
+        as local functions.  The nodes representing local function as called
         gates.  In our case, we limit our local functions to be either a 2-input
         AND or a 2-input XOR---a structure known as XAG.  Therefore, a XAG is a
         2-regular non-homogeneous logic network.
 
     Under the hood both representations are implemented in C++.
     """
+
     def __init__(self, f):
         if not isinstance(f, types.FunctionType):
             raise TypeError("Constructor requires a function")
@@ -51,7 +53,7 @@ class BoolFunction(object):
         i = 0
         result = list()
         for type_, size in self._return_signature:
-            tmp = sim_result[i:i+size]
+            tmp = sim_result[i : i + size]
             result.append(type_(size, tmp[::-1]))
             i += size
         if len(result) == 1:
@@ -72,27 +74,31 @@ class BoolFunction(object):
 
     def simulate(self, *argv):
         if len(argv) != self.num_inputs():
-            raise RuntimeError(f"The function requires {self.num_inputs()}. "
-                               f"It's signature is: {self._parameters_signature}")
+            raise RuntimeError(
+                f"The function requires {self.num_inputs()}. "
+                f"It's signature is: {self._parameters_signature}"
+            )
         input_str = str()
         for i, arg in enumerate(argv):
             arg_type = (type(arg), len(arg))
             if arg_type != self._parameters_signature[i]:
-                raise TypeError(f"Wrong argument type. Argument {i} "
-                                f"expected: {self._parameters_signature[i]}, "
-                                f"got: {arg_type}")
+                raise TypeError(
+                    f"Wrong argument type. Argument {i} "
+                    f"expected: {self._parameters_signature[i]}, "
+                    f"got: {arg_type}"
+                )
             arg_str = str(arg)
             input_str += arg_str[::-1]
-        
+
         # If the truth table was already computed, we just need to look for the
         # result of this particular input
         if self._truth_table != None:
             position = int(input_str[::-1], base=2)
-            sim_result = ''.join([str(int(tt[position])) for tt in self._truth_table])
+            sim_result = "".join([str(int(tt[position])) for tt in self._truth_table])
         else:
             input_vector = [bool(int(i)) for i in input_str]
             sim_result = classical.simulate(self._logic_network, input_vector)
-            sim_result = ''.join([str(int(i)) for i in sim_result])
+            sim_result = "".join([str(int(i)) for i in sim_result])
 
         return self._format_simulation_result(sim_result)
 
@@ -102,7 +108,7 @@ class BoolFunction(object):
 
         result = list()
         for position in range(2 ** self._logic_network.num_pis()):
-            sim_result = ''.join([str(int(tt[position])) for tt in self._truth_table])
+            sim_result = "".join([str(int(tt[position])) for tt in self._truth_table])
             result.append(self._format_simulation_result(sim_result))
 
         return result
@@ -110,7 +116,7 @@ class BoolFunction(object):
     def logic_network(self):
         return self._logic_network
 
-    def truth_table(self, output_bit : int):
+    def truth_table(self, output_bit: int):
         if not isinstance(output_bit, int):
             raise TypeError("Parameter output must be an integer")
         if self._truth_table == None:
@@ -124,15 +130,15 @@ class BoolFunction(object):
 
         A logical expression is composed of logical operators & (AND), | (OR),
         ~ (NOT), and ^ (XOR), as well as symbols for variables. For example,
-        'a & b' and '~(~(x0 | x1) ^ (~x0 & ~x1))' are both valid string 
+        'a & b' and '~(~(x0 | x1) ^ (~x0 & ~x1))' are both valid string
         representation of logical expressions.
 
         Logic expressions are parsed and stored, initially, as a LogicNetwork,
-        which is a XOR-AND graph (XAG). 
+        which is a XOR-AND graph (XAG).
 
         Args:
             expression: The string of the desired logical expression, such as
-                        'a & b' or '~(~(x0 | x1) ^ (~x0 & ~x1))' 
+                        'a & b' or '~(~(x0 | x1) ^ (~x0 & ~x1))'
 
         Returns:
             A BooleanFunction that uses a XAG to represent the logical expression
@@ -163,8 +169,8 @@ class BoolFunction(object):
         """Create a BooleanFunction from an truth table string.
 
         Truth tables are a common way of specifying boolean functions. They are
-        are an explicit and _not compact_ function representation---basically a 
-        truth table is an exhaustive mapping from input binary bit-strings of 
+        are an explicit and _not compact_ function representation---basically a
+        truth table is an exhaustive mapping from input binary bit-strings of
         length :math:`n` to corresponding output bit-strings of length :math:`m`.
         However, they are tremendously useful to represent and manipulate small
         functions.  For example, the following is a simple truth table that
@@ -183,10 +189,10 @@ class BoolFunction(object):
 
         In this case :math:`n=2`, and :math:`m=1`.  Note that, for compactness,
         the input bit-strings are omitted because they can be easily derived
-        for any given :math:`n`.  Hence to completely specify a truth table, 
+        for any given :math:`n`.  Hence to completely specify a truth table,
         we only need a Length-2 :sup:`n` bit-string for each of the :math:`m`
         outputs.  In the above example, a single bit-string `'1000'` is enough.
-        The most-significant bit corresponds to the :math:`f(1, 1)` and the 
+        The most-significant bit corresponds to the :math:`f(1, 1)` and the
         least-significant bit corresponds to :math:`f(0, 0)`.
 
         Args:
@@ -199,14 +205,14 @@ class BoolFunction(object):
         if isinstance(tts, str):
             tts = [tts]
 
-        # Check that the input binary stings have the same length and that this 
+        # Check that the input binary stings have the same length and that this
         # length is a power of 2
         if not ((len(tts[0]) & (len(tts[0]) - 1) == 0) and len(tts[0]) != 0):
             raise RuntimeError("Length of all binary string must be a power of 2")
         for tt in tts[1:]:
             if len(tt) != len(tts[0]):
                 raise RuntimeError("Length of all binary string must equal")
-        
+
         n_inputs = int(math.log(len(tts[0]), 2))
         n_outputs = len(tts)
 
@@ -225,16 +231,16 @@ class BoolFunction(object):
     def from_aiger_file(cls, path: str):
         """Create a BooleanFunction from an AIGER file.
 
-        AIGER is a binary format to store Boolean functions that are represented 
+        AIGER is a binary format to store Boolean functions that are represented
         as And-Inverter Graphs (AIGs).  An AIG is a 2-regular homogeneous logic
-        network, in which each gate function is the 2-input AND. Inverters are 
+        network, in which each gate function is the 2-input AND. Inverters are
         modelled using the complementation flags.
 
         The logic network used in `BoolFunction` is _not_ an AIG.  We use a XAG
         instead.  A XAG is a 2-regular non-homogeneous logic network, in which
-        each gate function is either a 2-input AND or a 2-input XOR.  Inverters 
+        each gate function is either a 2-input AND or a 2-input XOR.  Inverters
         are modelled using the complementation flags, but they are not strictly
-        necessary.  Thus this function reads an AIG from a AIGER file and 
+        necessary.  Thus this function reads an AIG from a AIGER file and
         transforms it into a XAG.
 
         Args:
@@ -258,16 +264,16 @@ class BoolFunction(object):
     def from_dimacs_file(cls, path: str):
         """Create a BooleanFunction from a DIMACS CNF file.
 
-        The `DIMACS CNF format 
-        <http://www.satcompetition.org/2009/format-benchmarks2009.html>`__, is 
-        the standard format for specifying SATisfiability (SAT) problem 
-        instances in `Conjunctive Normal Form (CNF) 
-        <https://en.wikipedia.org/wiki/Conjunctive_normal_form>`__, which is a 
+        The `DIMACS CNF format
+        <http://www.satcompetition.org/2009/format-benchmarks2009.html>`__, is
+        the standard format for specifying SATisfiability (SAT) problem
+        instances in `Conjunctive Normal Form (CNF)
+        <https://en.wikipedia.org/wiki/Conjunctive_normal_form>`__, which is a
         two-level representation of a Boolean function, in which the inner
-        operator is OR and the outter operator is AND.  Thus a CNF is a 
+        operator is OR and the outter operator is AND.  Thus a CNF is a
         conjunction of one or more clauses, where a clause is a disjunction of
         one or more literals.
-        
+
         Args:
             path: Path to the DIMACS file (*.cnf)
 
@@ -289,12 +295,12 @@ class BoolFunction(object):
     def from_verilog_file(cls, path: str):
         """Create a BooleanFunction from Verilog file.
 
-        /!\ This function can only parse a _very_ small and simple subset of 
+        /!\ This function can only parse a _very_ small and simple subset of
         /!\ the Verilog language.
 
         Verilog is a hardware description language (HDL) used to model
         electronic systems.  Here we are interested on its capability to model
-        purely combinational circuits.  
+        purely combinational circuits.
 
         Args:
             path: Path to the Verilog file (*.v)

--- a/python/tweedledum/bool_function_compiler/expression_parser.py
+++ b/python/tweedledum/bool_function_compiler/expression_parser.py
@@ -1,20 +1,26 @@
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Part of Tweedledum Project.  This file is distributed under the MIT License.
 # See accompanying file /LICENSE for details.
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 import ast
 
 from .bitvec import BitVec
 from .function_parser import FunctionParser, ParseError
 
+
 class ExpressionParser(FunctionParser):
+    def __init__(self, source, var_order: list = None):
+        self.var_order = var_order
+        super().__init__(source)
 
     def visit_Module(self, node):
         """The full snippet should contain a single function"""
         if len(node.body) != 1 or not isinstance(node.body[0], ast.Expr):
             raise ParseError("Not an expression to parse")
+        if self.var_order:
+            self._create_ordered_vars(node)
 
-        self._return_signature = [(self.types['BitVec'], 1)]
+        self._return_signature = [(self.types["BitVec"], 1)]
         expr_type, expr_signal = self.visit(node.body[0])
         if expr_type != self._return_signature[0]:
             raise ParseError("Expressions can only evaluate to a BitVec(1)")
@@ -24,8 +30,25 @@ class ExpressionParser(FunctionParser):
         return super().visit(node.value)
 
     def visit_Name(self, node):
-        if node.id not in self._symbol_table:
-            self._parameters_signature.append((self.types['BitVec'], 1))
-            self._symbol_table[node.id] = ((self.types['BitVec'], 1),
-                                           [self._logic_network.create_pi()])
-        return self._symbol_table[node.id]
+        return self._create_name(node.id)
+
+    def _create_name(self, name: str):
+        if name not in self._symbol_table:
+            self._parameters_signature.append((self.types["BitVec"], 1))
+            self._symbol_table[name] = (
+                (self.types["BitVec"], 1),
+                [self._logic_network.create_pi()],
+            )
+        return self._symbol_table[name]
+
+    def _create_ordered_vars(self, module):
+        vars = set()
+        for node in ast.walk(module):
+            if isinstance(node, ast.Name):
+                vars.add(node.id)
+        if vars != set(self.var_order):
+            raise ParseError(
+                f"Missing variables in order list {vars - set(self.var_order)}"
+            )
+        for var in self.var_order:
+            self._create_name(var)

--- a/python/tweedledum/classical/mockturtle.cpp
+++ b/python/tweedledum/classical/mockturtle.cpp
@@ -25,7 +25,6 @@ void init_mockturtle(pybind11::module& module)
 
     py::class_<xag_network>(module, "LogicNetwork")
         .def(py::init<>())
-        .def("get_constant", &xag_network::get_constant)
         .def("create_pi", &xag_network::create_pi, py::arg("name") = "")
         .def("create_po", &xag_network::create_po, py::arg("f"), py::arg("name") = "")
         // Operations
@@ -42,7 +41,12 @@ void init_mockturtle(pybind11::module& module)
         // Structural properties
         .def("num_gates", &xag_network::num_gates)
         .def("num_pis", &xag_network::num_pis)
-        .def("num_pos", &xag_network::num_pos);
+        .def("num_pos", &xag_network::num_pos)
+        // Node and signals
+        .def("get_constant", &xag_network::get_constant)
+        .def("get_node", &xag_network::get_node)
+        .def("pi_at", &xag_network::pi_at);
+
 
     // IO
     module.def("read_aiger", [](std::string const filename) {


### PR DESCRIPTION
<!-- Thanks for helping us improve tweedledum! -->

### Description
Allow users to define variable order when parsing expressions for
oracles. For example:

```python
ExpressionParser("((A & C) | (B & D)) & ~(C & D)", var_order=["A", "B", "C", "D"])
```

Variables `A, B, C, and D` will be placed on qubits `0, 1, 2, and 3`,
respectively. If this was called without an order:

```python
ExpressionParser("((A & C) | (B & D)) & ~(C & D)")
```

Then variables will be placed on qubits in order of appearance. That is,
`A, B, C, and D` will be placed on qubits  `0, 2, 1, and 3`, respectively.

<!-- Include relevant issues here, describe what changed and why -->

### Suggested changelog entry:
<!-- Fill in the below block with the expected RestructuredText entry.
     Delete if no entry needed; -->

```rst
Specify variable order for expressions parser
```

<!-- If the upgrade guide needs updating, note that here too -->
