### PR TITLE
Fix dir name 'lib' -> 'src'

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         sudo apt-get install lcov
         lcov -t "result" -o lcov.info -c -d .
-        lcov -e lcov.info "*tweedledum/include*" "*tweedledum/lib*"  -o lcov_filtered.info
+        lcov -e lcov.info "*tweedledum/include*" "*tweedledum/src*"  -o lcov_filtered.info
         lcov -l lcov_filtered.info
 
     - name: CodeCov


### PR DESCRIPTION
<!-- Thanks for helping us improve tweedledum! -->

### Description
<!-- Include relevant issues here, describe what changed and why -->

The codecov workflow was using old directory names.