### PR TITLE
SAT-based linear synthesis

### DIFF
--- a/include/tweedledum/Synthesis/Synthesis.h
+++ b/include/tweedledum/Synthesis/Synthesis.h
@@ -14,6 +14,7 @@
 #include "linear_synth.h"
 #include "pkrm_synth.h"
 #include "pprm_synth.h"
+#include "sat_linear_synth.h"
 #include "sat_swap_synth.h"
 #include "spectrum_synth.h"
 #include "steiner_gauss_synth.h"

--- a/include/tweedledum/Synthesis/sat_linear_synth.h
+++ b/include/tweedledum/Synthesis/sat_linear_synth.h
@@ -1,0 +1,29 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#pragma once
+
+#include "../IR/Circuit.h"
+#include "../Target/Device.h"
+#include "../Utils/Matrix.h"
+
+#include <nlohmann/json.hpp>
+#include <vector>
+
+namespace tweedledum {
+
+void sat_linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
+  std::vector<Cbit> const& cbits, BMatrix const& matrix,
+  nlohmann::json const& config = {});
+
+Circuit sat_linear_synth(
+  BMatrix const& matrix, nlohmann::json const& config = {});
+
+void sat_linear_synth(Device const& device, Circuit& circuit,
+  BMatrix const& linear_trans, nlohmann::json const& config = {});
+
+Circuit sat_linear_synth(Device const& device, BMatrix const& linear_trans,
+  nlohmann::json const& config = {});
+
+} // namespace tweedledum

--- a/include/tweedledum/Target/Device.h
+++ b/include/tweedledum/Target/Device.h
@@ -108,6 +108,11 @@ public:
         return edges_.at(i);
     }
 
+    std::vector<Edge> edges() const
+    {
+        return edges_;
+    }
+
     bool are_connected(uint32_t const v, uint32_t const u) const
     {
         assert(v <= num_qubits() && u <= num_qubits());

--- a/python/tweedledum/synthesis/synthesis.cpp
+++ b/python/tweedledum/synthesis/synthesis.cpp
@@ -98,6 +98,26 @@ void init_Synthesis(pybind11::module& module)
         py::arg("circuit"), py::arg("qubits"), py::arg("cbits"), py::arg("function"), py::arg("config") = nlohmann::json(),
         "Synthesize a quantum circuit inplace from a function by computing PPRM representation.");
 
+    module.def("sat_linear_synth",
+        py::overload_cast<BMatrix const&, nlohmann::json const&>(&sat_linear_synth),
+        py::arg("matrix"), py::arg("config") = nlohmann::json(),
+        "SAT-based synthesis of linear reversible circuits (CNOT synthesis).");
+
+    module.def("sat_linear_synth",
+        py::overload_cast<Circuit&, std::vector<Qubit> const&, std::vector<Cbit> const&, BMatrix const&, nlohmann::json const&>(&sat_linear_synth),
+        py::arg("circuit"), py::arg("qubits"), py::arg("cbits"), py::arg("matrix"), py::arg("config") = nlohmann::json(),
+        "SAT-based synthesis of linear reversible circuits (CNOT synthesis).");
+
+    module.def("sat_linear_synth",
+        py::overload_cast<Device const&, BMatrix const&, nlohmann::json const&>(&sat_linear_synth),
+        py::arg("device"), py::arg("matrix"), py::arg("config") = nlohmann::json(),
+        "SAT-based synthesis of linear reversible circuits (CNOT synthesis).");
+
+    module.def("sat_linear_synth",
+        py::overload_cast<Device const&, Circuit&, BMatrix const&, nlohmann::json const&>(&sat_linear_synth),
+        py::arg("device"), py::arg("circuit"), py::arg("matrix"), py::arg("config") = nlohmann::json(),
+        "SAT-based synthesis of linear reversible circuits (CNOT synthesis).");
+
     module.def("sat_swap_synth", 
         py::overload_cast<Device const&, std::vector<uint32_t> const&, std::vector<uint32_t> const&, nlohmann::json const&>(&sat_swap_synth),
         py::arg("device"), py::arg("init_cfg"), py::arg("final_cfg"), py::arg("config") = nlohmann::json(),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/pkrm_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/pprm_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/sat_swap_synth.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/sat_linear_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/spectrum_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/steiner_gauss_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/transform_synth.cpp

--- a/src/Synthesis/sat_linear_synth.cpp
+++ b/src/Synthesis/sat_linear_synth.cpp
@@ -1,0 +1,400 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#include "tweedledum/Synthesis/sat_linear_synth.h"
+#include "tweedledum/Operators/Standard/X.h"
+
+#include <bill/sat/cardinality.hpp>
+#include <bill/sat/solver.hpp>
+#include <vector>
+
+namespace tweedledum {
+
+namespace {
+
+template<typename Solver>
+class CXSwapEncoder {
+    using LBool = bill::lbool_type;
+    using Lit = bill::lit_type;
+    using Var = bill::var_type;
+
+public:
+    CXSwapEncoder(
+      Device const& device, BMatrix const& transform, Solver& solver)
+        : device_(&device)
+        , transform_(transform)
+        , use_symmetry_break_(true)
+        , num_moments_(0)
+        , offset_(num_matrix_vars() + num_ct_vars())
+        , solver_(solver)
+    {
+        assert(device_->num_qubits() == transform_.rows());
+    }
+
+    CXSwapEncoder(BMatrix const& transform, Solver& solver)
+        : device_(nullptr)
+        , transform_(transform)
+        , use_symmetry_break_(true)
+        , num_moments_(0)
+        , offset_(num_matrix_vars() + num_ct_vars())
+        , solver_(solver)
+    {}
+
+    void encode()
+    {
+        // Create matrix variables
+        solver_.add_variables(transform_.rows() * transform_.cols());
+
+        // Encode initial states
+        for (uint32_t row = 0u; row < transform_.rows(); ++row) {
+            for (uint32_t column = 0u; column < transform_.cols(); ++column) {
+                const auto polarity = (row == column) ? bill::positive_polarity
+                                                      : bill::negative_polarity;
+                Lit lit(matrix_var(0, row, column), polarity);
+                solver_.add_clause(lit);
+            }
+        }
+        // if (use_symmetry_break_) {
+        //     symmetry_break_matrix(num_moments_);
+        // }
+        ++num_moments_;
+    }
+
+    std::vector<Lit> encode_assumptions() const
+    {
+        std::vector<Lit> assumptions;
+        for (uint32_t row = 0u; row < num_qubits(); ++row) {
+            for (uint32_t column = 0u; column < num_qubits(); ++column) {
+                const auto polarity = transform_(row, column)
+                                      ? bill::positive_polarity
+                                      : bill::negative_polarity;
+                assumptions.emplace_back(
+                  matrix_var(num_moments_ - 1, row, column), polarity);
+            }
+        }
+        return assumptions;
+    }
+
+    void encode_new_moment()
+    {
+        encode_cx_gates(num_moments_ - 1);
+        assert((offset_ * num_moments_) == solver_.num_variables());
+
+        encode_transition(num_moments_);
+        if (use_symmetry_break_) {
+            symmetry_break_matrix(num_moments_);
+            if (num_moments_ >= 2) {
+                symmetry_break_transition(num_moments_ - 1);
+            }
+        }
+        ++num_moments_;
+    }
+
+    void decode(Circuit& circuit, std::vector<LBool> const& model)
+    {
+        for (uint32_t moment = 0u; moment < (num_moments_ - 1); ++moment) {
+            uint32_t control = 0u;
+            uint32_t target = 0u;
+            for (uint32_t row = 0u; row < num_qubits(); ++row) {
+                if (model.at(control_var(moment, row)) == LBool::true_) {
+                    control = row;
+                    assert(model.at(target_var(moment, row)) == LBool::false_);
+                } else if (model.at(target_var(moment, row)) == LBool::true_) {
+                    target = row;
+                    assert(model.at(control_var(moment, row)) == LBool::false_);
+                }
+            }
+            circuit.apply_operator(Op::X(), {Qubit(control), Qubit(target)});
+        }
+    }
+
+    void decode(Circuit& circuit, std::vector<Qubit> const& qubits,
+      std::vector<LBool> const& model)
+    {
+        for (uint32_t moment = 0u; moment < (num_moments_ - 1); ++moment) {
+            uint32_t control = 0u;
+            uint32_t target = 0u;
+            for (uint32_t row = 0u; row < num_qubits(); ++row) {
+                if (model.at(control_var(moment, row)) == LBool::true_) {
+                    control = row;
+                    assert(model.at(target_var(moment, row)) == LBool::false_);
+                } else if (model.at(target_var(moment, row)) == LBool::true_) {
+                    target = row;
+                    assert(model.at(control_var(moment, row)) == LBool::false_);
+                }
+            }
+            circuit.apply_operator(
+              Op::X(), {qubits.at(control), qubits.at(target)});
+        }
+    }
+
+private:
+    uint32_t num_matrix_vars() const
+    {
+        return transform_.rows() * transform_.rows();
+    }
+
+    // Number of control/target variables
+    uint32_t num_ct_vars() const
+    {
+        // Every qubit can be either a control or a target
+        return 2 * num_qubits();
+    }
+
+    uint32_t num_qubits() const
+    {
+        return transform_.rows();
+    }
+
+    void encode_cx_gates(uint32_t moment)
+    {
+        std::vector<Var> control;
+        std::vector<Var> target;
+
+        // Create control and target variables
+        solver_.add_variables(2 * num_qubits());
+
+        for (uint32_t row = 0u; row < num_qubits(); ++row) {
+            control.emplace_back(control_var(moment, row));
+            target.emplace_back(target_var(moment, row));
+        }
+        bill::at_least_one(control, solver_);
+        bill::at_most_one_pairwise(control, solver_);
+        bill::at_least_one(target, solver_);
+        bill::at_most_one_pairwise(target, solver_);
+
+        std::vector<Lit> clause;
+        for (uint32_t row = 0u; row < num_qubits(); ++row) {
+            clause.emplace_back(
+              control_var(moment, row), bill::negative_polarity);
+            clause.emplace_back(
+              target_var(moment, row), bill::negative_polarity);
+            solver_.add_clause(clause);
+            for (uint32_t column = 0u; device_ && column < num_qubits(); ++column) {
+                if (device_->are_connected(row, column)) {
+                    continue;
+                }
+                clause.back() =
+                  Lit(target_var(moment, column), bill::negative_polarity);
+                solver_.add_clause(clause);
+            }
+            clause.clear();
+        }
+    }
+
+    void encode_transition(uint32_t moment)
+    {
+        // Create matrix variables for new moment
+        solver_.add_variables(transform_.rows() * transform_.cols());
+
+        std::vector<Lit> clause;
+        for (uint32_t row = 0u; row < num_qubits(); ++row) {
+            for (uint32_t column = 0u; column < num_qubits(); ++column) {
+                clause.emplace_back(
+                  target_var(moment - 1, row), bill::positive_polarity);
+                clause.emplace_back(
+                  matrix_var(moment - 1, row, column), bill::negative_polarity);
+                clause.emplace_back(
+                  matrix_var(moment, row, column), bill::positive_polarity);
+                solver_.add_clause(clause);
+
+                clause.at(1) = Lit(
+                  matrix_var(moment - 1, row, column), bill::positive_polarity);
+                clause.at(2) =
+                  Lit(matrix_var(moment, row, column), bill::negative_polarity);
+                solver_.add_clause(clause);
+
+                encode_more_dependencies(moment, row, column);
+                clause.clear();
+            }
+        }
+    }
+
+    void encode_more_dependencies(
+      uint32_t moment, uint32_t row, uint32_t column)
+    {
+        for (uint32_t other_row = 0u; other_row < num_qubits(); ++other_row) {
+            if (other_row == row) {
+                continue;
+            }
+            std::vector<Lit> clause;
+            clause.emplace_back(
+              target_var(moment - 1, row), bill::negative_polarity);
+            clause.emplace_back(
+              control_var(moment - 1, other_row), bill::negative_polarity);
+
+            clause.emplace_back(
+              matrix_var(moment - 1, row, column), bill::negative_polarity);
+            clause.emplace_back(matrix_var(moment - 1, other_row, column),
+              bill::negative_polarity);
+            clause.emplace_back(
+              matrix_var(moment, row, column), bill::negative_polarity);
+            solver_.add_clause(clause);
+
+            clause.at(3).complement();
+            clause.at(4).complement();
+            solver_.add_clause(clause);
+
+            clause.at(2).complement();
+            clause.at(3).complement();
+            solver_.add_clause(clause);
+
+            clause.at(3).complement();
+            clause.at(4).complement();
+            solver_.add_clause(clause);
+        }
+    }
+
+    void symmetry_break_matrix(uint32_t moment)
+    {
+        std::vector<Lit> clause;
+        /* there cannot be a row with all zeroes */
+        for (uint32_t row = 0u; row < num_qubits(); ++row) {
+            for (uint32_t column = 0u; column < num_qubits(); ++column) {
+                clause.emplace_back(
+                  matrix_var(moment, row, column), bill::positive_polarity);
+            }
+            solver_.add_clause(clause);
+        }
+        clause.clear();
+
+        /* there cannot be a column with all zeroes */
+        for (uint32_t column = 0u; column < num_qubits(); ++column) {
+            for (uint32_t row = 0u; row < num_qubits(); ++row) {
+                clause.emplace_back(
+                  matrix_var(moment, row, column), bill::positive_polarity);
+            }
+            solver_.add_clause(clause);
+        }
+    }
+
+    void symmetry_break_transition(uint32_t moment)
+    {
+        std::vector<Lit> clause;
+
+        /* same control, first target must be smaller than others */
+        for (uint32_t control0 = 0u; control0 < num_qubits(); ++control0) {
+            for (uint32_t target0 = 1u; target0 < num_qubits(); ++target0) {
+                if (control0 == target0) {
+                    continue;
+                }
+                for (uint32_t target1 = 0u; target1 < target0; ++target1) {
+                    if (control0 == target1) {
+                        continue;
+                    }
+                    clause.emplace_back(control_var(moment - 1, control0),
+                      bill::negative_polarity);
+                    clause.emplace_back(
+                      control_var(moment, control0), bill::negative_polarity);
+                    clause.emplace_back(
+                      target_var(moment - 1, target0), bill::negative_polarity);
+                    clause.emplace_back(
+                      target_var(moment, target1), bill::negative_polarity);
+                    solver_.add_clause(clause);
+                    clause.clear();
+                }
+            }
+        }
+    }
+
+    Var matrix_var(uint32_t moment, uint32_t row, uint32_t column) const
+    {
+        Var var = (moment * offset_) + (row * num_qubits()) + column;
+        assert(var < Var(solver_.num_variables()));
+        return var;
+    }
+
+    Var control_var(uint32_t moment, uint32_t row) const
+    {
+        Var var = moment * offset_ + num_matrix_vars() + row;
+        assert(var < Var(solver_.num_variables()));
+        return var;
+    }
+
+    Var target_var(uint32_t moment, uint32_t row) const
+    {
+        Var var = moment * offset_ + num_matrix_vars() + num_qubits() + row;
+        assert(var < Var(solver_.num_variables()));
+        return var;
+    }
+
+    Device const* device_;
+    BMatrix const& transform_;
+
+    // Parameters
+    bool use_symmetry_break_;
+
+    // Encoded problem
+    uint32_t num_moments_;
+    uint32_t offset_;
+    Solver& solver_;
+};
+
+} // namespace
+
+void sat_linear_synth(Circuit& circuit, std::vector<Qubit> const& qubits,
+  std::vector<Cbit> const& cbits, BMatrix const& transform,
+  [[maybe_unused]] nlohmann::json const& config)
+{
+    bill::solver solver;
+    CXSwapEncoder encoder(transform, solver);
+    encoder.encode();
+    do {
+        std::vector<bill::lit_type> assumptions = encoder.encode_assumptions();
+        solver.solve(assumptions);
+        bill::result result = solver.get_result();
+        if (result) {
+            encoder.decode(circuit, qubits, result.model());
+            return;
+        }
+        encoder.encode_new_moment();
+    } while (1);
+}
+
+Circuit sat_linear_synth(BMatrix const& transform, nlohmann::json const& config)
+{
+    Circuit circuit;
+    std::vector<Qubit> qubits;
+    qubits.reserve(transform.rows());
+    for (uint32_t i = 0u; i < transform.rows(); ++i) {
+        qubits.emplace_back(circuit.create_qubit());
+    }
+    sat_linear_synth(circuit, qubits, {}, transform, config);
+    return circuit;
+}
+
+void sat_linear_synth(Device const& device, Circuit& circuit,
+  BMatrix const& transform, [[maybe_unused]] nlohmann::json const& config)
+{
+    assert(transform.rows() <= 32);
+
+    bill::solver solver;
+    CXSwapEncoder encoder(device, transform, solver);
+    encoder.encode();
+    do {
+        std::vector<bill::lit_type> assumptions = encoder.encode_assumptions();
+        solver.solve(assumptions);
+        bill::result result = solver.get_result();
+        if (result) {
+            encoder.decode(circuit, result.model());
+            return;
+        }
+        encoder.encode_new_moment();
+    } while (1);
+}
+
+Circuit sat_linear_synth(
+  Device const& device, BMatrix const& transform, nlohmann::json const& config)
+{
+    Circuit circuit;
+    std::vector<Qubit> qubits;
+    qubits.reserve(transform.rows());
+    for (uint32_t i = 0u; i < transform.rows(); ++i) {
+        qubits.emplace_back(circuit.create_qubit());
+    }
+    sat_linear_synth(device, circuit, transform, config);
+    return circuit;
+}
+
+} // namespace tweedledum

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ set(tweedledum_tests_files
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/linear_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/pkrm_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/pprm_synth.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/sat_linear_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/sat_swap_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/spectrum_synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Synthesis/steiner_gauss_synth.cpp

--- a/tests/Synthesis/sat_linear_synth.cpp
+++ b/tests/Synthesis/sat_linear_synth.cpp
@@ -130,7 +130,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 1, 0, 0,
                      0, 1, 0,
                      0, 0, 1;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     SECTION("Swap (q0 , q1)")
@@ -139,7 +139,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 0, 1, 0,
                      1, 0, 0,
                      0, 0, 1;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     SECTION("Swap (q0 , q2)")
@@ -148,7 +148,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 0, 0, 1,
                      0, 1, 0,
                      1, 0, 0;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     SECTION("2 Swaps (q1, q2) (q0, 1)")
@@ -158,7 +158,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 0, 0, 1, 
                      1, 0, 0,
                      0, 1, 0;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     SECTION("Upper triangle")
@@ -168,7 +168,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 1, 1, 1,
                      0, 1, 1,
                      0, 0, 1;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     SECTION("Lower triangle")
@@ -178,7 +178,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 1, 0, 0,
                      1, 1, 0,
                      1, 1, 1;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     SECTION("Two CX to q0")
@@ -188,7 +188,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 1, 1, 1,
                      0, 1, 0,
                      0, 0, 1;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     SECTION("Two CX to q1")
@@ -198,7 +198,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 1, 0, 0,
                      1, 1, 1,
                      0, 0, 1;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     SECTION("Two CX to q2")
@@ -208,7 +208,7 @@ TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
         transform << 1, 0, 0,
                      0, 1, 0,
                      1, 1, 1;
-        Circuit synthesized = sat_linear_synth(transform);
+        Circuit synthesized = sat_linear_synth(path_3, transform);
         CHECK(check_unitary(expected, synthesized));
     }
     // clang-format on

--- a/tests/Synthesis/sat_linear_synth.cpp
+++ b/tests/Synthesis/sat_linear_synth.cpp
@@ -1,0 +1,215 @@
+/*------------------------------------------------------------------------------
+| Part of Tweedledum Project.  This file is distributed under the MIT License.
+| See accompanying file /LICENSE for details.
+*-----------------------------------------------------------------------------*/
+#include "tweedledum/Synthesis/sat_linear_synth.h"
+
+#include "tweedledum/IR/Circuit.h"
+#include "tweedledum/Operators/Standard/Swap.h"
+#include "tweedledum/Operators/Standard/X.h"
+#include "tweedledum/Target/Device.h"
+#include "tweedledum/Utils/Matrix.h"
+
+#include "../check_unitary.h"
+
+#include <catch.hpp>
+#include <nlohmann/json.hpp>
+
+TEST_CASE("Trivial cases for non-constrained SAT linear synthesis",
+  "[sat_linear_synth][synth]")
+{
+    using namespace tweedledum;
+    BMatrix transform = BMatrix::Identity(3, 3);
+    Circuit expected;
+    Qubit q0 = expected.create_qubit();
+    Qubit q1 = expected.create_qubit();
+    Qubit q2 = expected.create_qubit();
+    // clang-format off
+    SECTION("Identity")
+    {
+        transform << 1, 0, 0,
+                     0, 1, 0,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Swap (q0 , q1)")
+    {
+        expected.apply_operator(Op::Swap(), {q0, q1});
+        transform << 0, 1, 0,
+                     1, 0, 0,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Swap (q0 , q2)")
+    {
+        expected.apply_operator(Op::Swap(), {q0, q2});
+        transform << 0, 0, 1,
+                     0, 1, 0,
+                     1, 0, 0;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("2 Swaps (q1, q2) (q0, 1)")
+    {
+        expected.apply_operator(Op::Swap(), {q1, q2});
+        expected.apply_operator(Op::Swap(), {q0, q1});
+        transform << 0, 0, 1, 
+                     1, 0, 0,
+                     0, 1, 0;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Upper triangle")
+    {
+        expected.apply_operator(Op::X(), {q2, q1});
+        expected.apply_operator(Op::X(), {q1, q0});
+        transform << 1, 1, 1,
+                     0, 1, 1,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Lower triangle")
+    {
+        expected.apply_operator(Op::X(), {q0, q1});
+        expected.apply_operator(Op::X(), {q1, q2});
+        transform << 1, 0, 0,
+                     1, 1, 0,
+                     1, 1, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Two CX to q0")
+    {
+        expected.apply_operator(Op::X(), {q1, q0});
+        expected.apply_operator(Op::X(), {q2, q0});
+        transform << 1, 1, 1,
+                     0, 1, 0,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Two CX to q1")
+    {
+        expected.apply_operator(Op::X(), {q0, q1});
+        expected.apply_operator(Op::X(), {q2, q1});
+        transform << 1, 0, 0,
+                     1, 1, 1,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Two CX to q2")
+    {
+        expected.apply_operator(Op::X(), {q0, q2});
+        expected.apply_operator(Op::X(), {q1, q2});
+        transform << 1, 0, 0,
+                     0, 1, 0,
+                     1, 1, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    // clang-format on
+}
+
+TEST_CASE("Trivial path cases for constrained SAT linear synthesis",
+  "[sat_linear_synth][synth]")
+{
+    using namespace tweedledum;
+    Device path_3 = Device::path(3);
+    BMatrix transform = BMatrix::Identity(3, 3);
+    Circuit expected;
+    Qubit q0 = expected.create_qubit();
+    Qubit q1 = expected.create_qubit();
+    Qubit q2 = expected.create_qubit();
+    // clang-format off
+    SECTION("Identity")
+    {
+        transform << 1, 0, 0,
+                     0, 1, 0,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Swap (q0 , q1)")
+    {
+        expected.apply_operator(Op::Swap(), {q0, q1});
+        transform << 0, 1, 0,
+                     1, 0, 0,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Swap (q0 , q2)")
+    {
+        expected.apply_operator(Op::Swap(), {q0, q2});
+        transform << 0, 0, 1,
+                     0, 1, 0,
+                     1, 0, 0;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("2 Swaps (q1, q2) (q0, 1)")
+    {
+        expected.apply_operator(Op::Swap(), {q1, q2});
+        expected.apply_operator(Op::Swap(), {q0, q1});
+        transform << 0, 0, 1, 
+                     1, 0, 0,
+                     0, 1, 0;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Upper triangle")
+    {
+        expected.apply_operator(Op::X(), {q2, q1});
+        expected.apply_operator(Op::X(), {q1, q0});
+        transform << 1, 1, 1,
+                     0, 1, 1,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Lower triangle")
+    {
+        expected.apply_operator(Op::X(), {q0, q1});
+        expected.apply_operator(Op::X(), {q1, q2});
+        transform << 1, 0, 0,
+                     1, 1, 0,
+                     1, 1, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Two CX to q0")
+    {
+        expected.apply_operator(Op::X(), {q1, q0});
+        expected.apply_operator(Op::X(), {q2, q0});
+        transform << 1, 1, 1,
+                     0, 1, 0,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Two CX to q1")
+    {
+        expected.apply_operator(Op::X(), {q0, q1});
+        expected.apply_operator(Op::X(), {q2, q1});
+        transform << 1, 0, 0,
+                     1, 1, 1,
+                     0, 0, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    SECTION("Two CX to q2")
+    {
+        expected.apply_operator(Op::X(), {q0, q2});
+        expected.apply_operator(Op::X(), {q1, q2});
+        transform << 1, 0, 0,
+                     0, 1, 0,
+                     1, 1, 1;
+        Circuit synthesized = sat_linear_synth(transform);
+        CHECK(check_unitary(expected, synthesized));
+    }
+    // clang-format on
+}


### PR DESCRIPTION
<!-- Thanks for helping us improve tweedledum! -->

### Description
<!-- Include relevant issues here, describe what changed and why -->
This PR includes an initial implementation for a SAT-based linear
synthesis method that also works under coupling constraints.

```python
from tweedledum.target import Device
from tweedledum.synthesis import sat_linear_synth

path3 = Device.path(3)
linear_trans = [[1,1,1], 
                [0,1,0], 
                [0,0,1]]
circuit = sat_linear_synth(path3, linear_trans)
print(circuit)
```
Results:
```
__q2 : ──●─────────●──
       ╭─┴─╮     ╭─┴─╮
__q1 : ┤ x ├──●──┤ x ├
       ╰───╯╭─┴─╮╰───╯
__q0 : ─────┤ x ├─────
            ╰───╯     
```

In comparison, `stainer_gauss_synth`:
```
__q2 : ───────●─────────●───────
            ╭─┴─╮     ╭─┴─╮     
__q1 : ──●──┤ x ├──●──┤ x ├──●──
       ╭─┴─╮╰───╯╭─┴─╮╰───╯╭─┴─╮
__q0 : ┤ x ├─────┤ x ├─────┤ x ├
       ╰───╯     ╰───╯     ╰───╯
```

The method guarantees finding an optimum solution. However,
It scales horribly on the number of qubits. But should be enough
to run some small experiments and be used to understand how to
improve `stainer_gauss_synth`.

### Suggested changelog entry:
<!-- Fill in the below block with the expected RestructuredText entry.
     Delete if no entry needed; -->

```rst
SAT-based linear synthesis.
```

<!-- If the upgrade guide needs updating, note that here too -->
