### PR TITLE
Improving `steiner_gauss_synth`

### DIFF
--- a/tests/Synthesis/steiner_gauss_synth.cpp
+++ b/tests/Synthesis/steiner_gauss_synth.cpp
@@ -94,3 +94,29 @@ TEST_CASE(
         CHECK(check_unitary(expected, synthesized));
     }
 }
+
+TEST_CASE("Swap extremities", "[steiner_gauss_synth][synth]")
+{
+    BMatrix linear_trans(8, 8);
+    Device path = Device::path(8);
+    Circuit expected;
+    Qubit q0 = expected.create_qubit();
+    expected.create_qubit();
+    expected.create_qubit();
+    expected.create_qubit();
+    expected.create_qubit();
+    expected.create_qubit();
+    expected.create_qubit();
+    Qubit q7 = expected.create_qubit();
+    expected.apply_operator(Op::Swap(), {q0, q7});
+    linear_trans << 0,0,0,0,0,0,0,1, 
+                    0,1,0,0,0,0,0,0,
+                    0,0,1,0,0,0,0,0,
+                    0,0,0,1,0,0,0,0,
+                    0,0,0,0,1,0,0,0,
+                    0,0,0,0,0,1,0,0,
+                    0,0,0,0,0,0,1,0,
+                    1,0,0,0,0,0,0,0;
+    Circuit synthesized = steiner_gauss_synth(path, linear_trans);
+    CHECK(check_unitary(expected, synthesized));
+}


### PR DESCRIPTION
### Description
<!-- Include relevant issues here, describe what changed and why -->
When doing gaussian elimination, I was using a trick to solve both the
upper and lower triangle of the matrix at the same time.  (I picked the
trick up on the staq codebase.) It turns out this was not a good idea
because it lead to subpar results.

```python
from tweedledum.target import Device
from tweedledum.synthesis import linear_synth, steiner_gauss_synth
from tweedledum.passes import compute_depth

path = Device.path(8)
linear_trans = [[0,0,0,0,0,0,0,1], 
                [0,1,0,0,0,0,0,0], 
                [0,0,1,0,0,0,0,0],
                [0,0,0,1,0,0,0,0],
                [0,0,0,0,1,0,0,0],
                [0,0,0,0,0,1,0,0],
                [0,0,0,0,0,0,1,0],
                [1,0,0,0,0,0,0,0]]
circuit = steiner_gauss_synth(path, linear_trans)
print(len(circuit))
print(compute_depth(circuit))
```

Previously this produced a circuit of size `100` and depth `80`.

Not it produces a circuit of size `64` and depth `54`.

Furthermore, when synthesizing circuits to compute all possible permutations 
on a path of 8 vertices. It used to find that this algorithm was only better than
a swap-based method in 1271 out of 40319 permutations (roughly 3.15%). Now it
finds better results for 5028 (12.47%). 

It also "solves" the examples in #157 

<!-- If the upgrade guide needs updating, note that here too -->
