### PR TITLE
Updated linguist's calculation to better reflect source language metric on GitHub 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.qasm linguist-vendored


### PR DESCRIPTION
The source language for tweedledum is C++ whereas GitHub's metric depicts OpenQASM to be the predominant source (which isn't true). This PR aims to fix this.