### PR TITLE
fix warnings generated by escape sequence in docstring

### DIFF
--- a/python/tweedledum/bool_function_compiler/bool_function.py
+++ b/python/tweedledum/bool_function_compiler/bool_function.py
@@ -296,7 +296,7 @@ class BoolFunction(object):
 
     @classmethod
     def from_verilog_file(cls, path: str):
-        """Create a BooleanFunction from Verilog file.
+        r"""Create a BooleanFunction from Verilog file.
 
         /!\ This function can only parse a _very_ small and simple subset of
         /!\ the Verilog language.


### PR DESCRIPTION
<!-- Thanks for helping us improve tweedledum! -->

### Description
<!-- Include relevant issues here, describe what changed and why -->

One of the docstrings contained the text `/!\ This function can only parse a _very_ small and simple subset of`, which generates a warning `DeprecationWarning: invalid escape sequence \ `.
This PR fixes this by making the docstring a raw string.

@boschmitt 

### Suggested changelog entry:
<!-- Fill in the below block with the expected RestructuredText entry.
     Delete if no entry needed; -->

No entry needed

<!-- If the upgrade guide needs updating, note that here too -->
