### PR TITLE
Add support for Python 3.11 and drop 3.6 support

### DIFF
--- a/.github/workflows/build_dev_wheels.yml
+++ b/.github/workflows/build_dev_wheels.yml
@@ -163,7 +163,7 @@ jobs:
             arch: ${{ matrix.arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ARCHS: all
@@ -172,6 +172,7 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: "CC=cl.exe CXX=cl.exe"
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --import-mode importlib -v {project}/python/test/
+          CIBW_SKIP: "cp36*"
           CMAKE_BUILD_PARALLEL_LEVEL: 2
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target }}
           TWEEDLEDUM_DEV_VERSION: ${{needs.setup_date.outputs.timestamp}}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -153,7 +153,7 @@ jobs:
             arch: ${{ matrix.arch }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_BUILD: ${{ matrix.build }}
           CIBW_ARCHS: all
@@ -161,6 +161,7 @@ jobs:
           CIBW_ENVIRONMENT_WINDOWS: "CC=cl.exe CXX=cl.exe"
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest --import-mode importlib -v {project}/python/test/
+          CIBW_SKIP: "cp36*"
           CMAKE_BUILD_PARALLEL_LEVEL: 2
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.target }}
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
       - name: Checkout code

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,10 @@ classifiers =
     Operating System :: POSIX :: Linux
     Programming Language :: C++
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development :: Compilers
     Topic :: Software Development :: Libraries


### PR DESCRIPTION


<!-- Thanks for helping us improve tweedledum! -->

### Description

This commit updates the supported python versions in the trove classifiers in the Python package metadata along with also updating the test and wheel build matrix to support Python versions 3.7 through 3.11. Python 3.6 which was previously supported has been dropped as it went EoL in December 2021. Python 3.11 was recently released on 10-24-2022 so it will be good to have precompiled binaries available for it.
<!-- Include relevant issues here, describe what changed and why -->

### Suggested changelog entry:

```rst
The supported Python versions for tweedledum have changed to be 3.7, 3.8, 3.9, 3.10, and 3.11. Support for using
tweedledum with Python 3.6 has been dropped as that version of Python has gone end of life.
```

<!-- If the upgrade guide needs updating, note that here too -->
