### PR TITLE
Make Euler angles publicly accessible for U operator

### DIFF
--- a/include/tweedledum/Operators/Standard/U.h
+++ b/include/tweedledum/Operators/Standard/U.h
@@ -29,6 +29,21 @@ public:
         return U(-theta_, -phi_, -lambda_);
     }
 
+    double theta() const
+    {
+        return theta_;
+    }
+
+    double phi() const
+    {
+        return phi_;
+    }
+
+    double lambda() const
+    {
+        return lambda_;
+    }
+
     UMatrix2 const matrix() const
     {
         using namespace std::complex_literals;


### PR DESCRIPTION
### Description
Not too exciting, just surface the Euler angles for the `U` operator for library users. This useful if you are transpiling Tweedledum circuit IR to another IR

Let me know if I should add a test for this (I wasn't sure how to shoehorn this into `rotation_angle()`)